### PR TITLE
refactor: use shared COP formatter in CartDrawer

### DIFF
--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -2,14 +2,8 @@
 import { useEffect, useState } from "react";
 import { useCart } from "../context/CartContext";
 import { getTableId } from "../utils/table";
+import { COP } from "../utils/money";
 
-function COP(n) {
-  try {
-    return new Intl.NumberFormat("es-CO").format(Math.round(n || 0));
-  } catch {
-    return String(n || 0);
-  }
-}
 const PHONE = import.meta.env.VITE_WHATSAPP || "573222285900";
 const NOTE_KEY = "aa_order_note";
 


### PR DESCRIPTION
## Summary
- remove local COP function in CartDrawer
- reuse utility COP from utils/money for price formatting

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6aae3fed083278db45e47e92f948b