### PR TITLE
Fix useQueryParam for server environments

### DIFF
--- a/src/utils/useQueryParam.js
+++ b/src/utils/useQueryParam.js
@@ -1,7 +1,10 @@
 import { useMemo } from "react";
+
 export function useQueryParam(name) {
-  return useMemo(
-    () => new URLSearchParams(window.location.search).get(name),
-    [name]
-  );
+  return useMemo(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    return new URLSearchParams(window.location.search).get(name);
+  }, [name, typeof window !== "undefined" ? window.location.search : null]);
 }


### PR DESCRIPTION
## Summary
- guard `useQueryParam` against missing `window`
- rerun memo when `window.location.search` changes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6abb79de883279b08a7aada4293fc