### PR TITLE
Fix typo in footer credits

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -92,7 +92,7 @@ export default function Footer() {
       </div>
 
       <p className="mt-5 text-[11px] text-neutral-500">
-        Diseñado por Sebas (UXIO) Y desarrolado con{" "}
+        Diseñado por Sebas (UXIO) y desarrollado con{" "}
         <span className="font-semibold">GPT-5 Thinking</span> ✨
       </p>
     </footer>


### PR DESCRIPTION
## Summary
- fix typo in footer credits

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6ad6d41688327bd0fb689fd7784d2