### PR TITLE
Add aria-hidden to decorative images

### DIFF
--- a/src/components/BrandDecor.jsx
+++ b/src/components/BrandDecor.jsx
@@ -10,24 +10,28 @@ export default function BrandDecor() {
       <img
         src="/decor-tl.png"
         alt=""
+        aria-hidden="true"
         className="decor-img decor-tl"
         onError={hideIfMissing}
       />
       <img
         src="/decor-tr.png"
         alt=""
+        aria-hidden="true"
         className="decor-img decor-tr"
         onError={hideIfMissing}
       />
       <img
         src="/decor-bl.png"
         alt=""
+        aria-hidden="true"
         className="decor-img decor-bl"
         onError={hideIfMissing}
       />
       <img
         src="/decor-br.png"
         alt=""
+        aria-hidden="true"
         className="decor-img decor-br"
         onError={hideIfMissing}
       />


### PR DESCRIPTION
## Summary
- hide decorative corner images from screen readers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6ad77f6e483278de73df2dde16c5e