### PR TITLE
feat: unify add button styling

### DIFF
--- a/src/components/BowlBuilderModal.jsx
+++ b/src/components/BowlBuilderModal.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { Button } from "./Buttons";
+import { AddButton } from "./Buttons";
 import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 
@@ -329,12 +329,9 @@ export default function BowlBuilderModal({ open, onClose }) {
             <div className="rounded-xl border bg-neutral-50 p-3">
               <p className="text-xs text-neutral-600">Total</p>
               <p className="text-xl font-bold">${COP(price)}</p>
-              <button
-                className="btn btn-primary mt-2 w-full"
-                onClick={addToCart}
-              >
+              <AddButton className="mt-2" onClick={addToCart}>
                 Añadir al carrito
-              </button>
+              </AddButton>
             </div>
           </div>
         </div>

--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
-import { Button } from "./Buttons";
+import { AddButton } from "./Buttons";
 import BowlBuilderModal from "./BowlBuilderModal";
 import stock from "../data/stock.json";
 
@@ -87,14 +87,10 @@ export default function BowlsSection() {
         </div>
         <div className="text-right shrink-0">
           <p className="font-bold">${COP(PREBOWL.price)}</p>
-          <Button
-            variant="outline"
-            className="mt-1"
-            onClick={addPre}
-            disabled={disabled}
-          >
-            {disabled ? "Agotado" : "Añadir"}
-          </Button>
+          <AddButton className="mt-1" onClick={addPre} disabled={disabled} />
+          {disabled && (
+            <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+          )}
         </div>
       </div>
 

--- a/src/components/Buttons.jsx
+++ b/src/components/Buttons.jsx
@@ -19,3 +19,43 @@ export function Button({ variant = "primary", className = "", ...props }) {
   const base = "btn " + (variant === "primary" ? "btn-primary" : "btn-outline");
   return <button {...props} className={base + " " + className} />;
 }
+
+export function AddButton({
+  children = "Añadir",
+  className = "",
+  disabled,
+  onClick,
+  type = "button",
+}) {
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      onClick={onClick}
+      className={[
+        "inline-flex items-center justify-center gap-2 rounded-full font-semibold shadow-sm transition select-none",
+        "bg-emerald-700 text-white hover:bg-emerald-800",
+        "border border-emerald-800/10",
+        "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-300",
+        "px-4 h-11 w-full sm:w-auto sm:h-10",
+        "active:translate-y-px",
+        "disabled:bg-neutral-200 disabled:text-neutral-500 disabled:cursor-not-allowed",
+        className,
+      ].join(" ")}
+    >
+      <svg
+        viewBox="0 0 24 24"
+        className="w-4 h-4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      >
+        <path d="M12 5v14M5 12h14" />
+      </svg>
+      <span>{children}</span>
+    </button>
+  );
+}
+
+export default AddButton;

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button } from "./Buttons";
+import { AddButton } from "./Buttons";
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
 import stock from "../data/stock.json";
@@ -315,14 +315,14 @@ export default function CoffeeSection() {
                   <div className="text-right shrink-0">
                     <p className="text-xs text-neutral-500">Precio</p>
                     <p className="font-semibold">${COP(finalPrice(item))}</p>
-                    <Button
-                      variant="outline"
+                    <AddButton
                       className="mt-1"
                       onClick={() => addToCart(item)}
                       disabled={disabled}
-                    >
-                      {disabled ? "Agotado" : "Añadir"}
-                    </Button>
+                    />
+                    {disabled && (
+                      <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+                    )}
                   </div>
                 </div>
               </li>
@@ -366,14 +366,14 @@ export default function CoffeeSection() {
                   <div className="text-right shrink-0">
                     <p className="text-xs text-neutral-500">Precio</p>
                     <p className="font-semibold">${COP(finalPrice(item))}</p>
-                    <Button
-                      variant="outline"
+                    <AddButton
                       className="mt-1"
                       onClick={() => addToCart(item)}
                       disabled={disabled}
-                    >
-                      {disabled ? "Agotado" : "Añadir"}
-                    </Button>
+                    />
+                    {disabled && (
+                      <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+                    )}
                   </div>
                 </div>
               </li>

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -1,6 +1,7 @@
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
 import stock from "../data/stock.json"; // ← sin assert
+import { AddButton } from "./Buttons";
 
 // estado global: 'ok' | 'low' | 'out'
 function stateFor(productId) {
@@ -168,22 +169,21 @@ export function Desserts() {
               <div
                 key={s.id}
                 className={
-                  "flex items-center justify-between gap-2 rounded-lg border px-3 py-2 " +
+                  "rounded-lg border px-3 py-2 " +
                   (disabled ? "opacity-60" : "")
                 }
               >
-                <div className="flex items-center gap-2">
-                  <span className="text-sm">{s.label}</span>
-                  {st === "low" && (
-                    <span className="badge badge-warn">Pocas unidades</span>
-                  )}
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm">{s.label}</span>
+                    {st === "low" && (
+                      <span className="badge badge-warn">Pocas unidades</span>
+                    )}
+                  </div>
+                  <span className="font-semibold">${COP(price)}</span>
                 </div>
-                <button
-                  disabled={disabled}
-                  className={
-                    "btn btn-outline " +
-                    (disabled ? "opacity-60 cursor-not-allowed" : "")
-                  }
+                <AddButton
+                  className="mt-2"
                   onClick={() =>
                     addItem({
                       productId: "cumbre",
@@ -192,9 +192,11 @@ export function Desserts() {
                       options: { Sabor: s.label },
                     })
                   }
-                >
-                  Añadir · ${COP(price)}
-                </button>
+                  disabled={disabled}
+                />
+                {disabled && (
+                  <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+                )}
               </div>
             );
           })}
@@ -238,18 +240,16 @@ function ProductRow({ item }) {
       </div>
       <div className="text-right shrink-0">
         <p className="font-semibold">${COP(item.price)}</p>
-        <button
-          disabled={disabled}
-          className={
-            "btn btn-outline mt-1 " +
-            (disabled ? "opacity-60 cursor-not-allowed" : "")
-          }
+        <AddButton
+          className="mt-1"
           onClick={() =>
             addItem({ productId: item.id, name: item.name, price: item.price })
           }
-        >
-          {disabled ? "Agotado" : "Añadir"}
-        </button>
+          disabled={disabled}
+        />
+        {disabled && (
+          <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+        )}
       </div>
     </li>
   );

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Chip, Button } from "./Buttons";
+import { Chip, AddButton } from "./Buttons";
 import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 import stock from "../data/stock.json"; // ← sin assert
@@ -119,14 +119,14 @@ export default function Sandwiches() {
               </div>
               <div className="text-right shrink-0">
                 <p className="font-semibold">${COP(priceFor(it.key))}</p>
-                <Button
-                  variant="outline"
+                <AddButton
                   className="mt-1"
                   onClick={() => add(it)}
                   disabled={disabled}
-                >
-                  {disabled ? "Agotado" : "Añadir"}
-                </Button>
+                />
+                {disabled && (
+                  <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+                )}
                 {priceByItem[it.key].unico && (
                   <p className="text-[11px] text-neutral-500 mt-1">
                     Precio único

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -1,4 +1,4 @@
-import { Button } from "./Buttons";
+import { AddButton } from "./Buttons";
 import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 import stock from "../data/stock.json";
@@ -66,14 +66,14 @@ function List({ items, onAdd }) {
             </div>
             <div className="text-right shrink-0">
               <p className="font-semibold">${COP(p.price)}</p>
-              <Button
-                variant="outline"
+              <AddButton
                 className="mt-1"
                 onClick={() => onAdd(p)}
                 disabled={disabled}
-              >
-                {disabled ? "Agotado" : "Añadir"}
-              </Button>
+              />
+              {disabled && (
+                <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+              )}
             </div>
           </li>
         );


### PR DESCRIPTION
## Summary
- add reusable AddButton with emerald brand styling and plus icon
- replace all "Añadir" buttons across sections with AddButton
- show stock messages outside disabled buttons and remove price from button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6b0ed48b883279afc3a0e46ca58ce