### PR TITLE
style: compact AddButton and reposition

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -75,23 +75,29 @@ export default function BowlsSection() {
       </button>
 
       {/* Card del prearmado */}
-      <div className="card p-4 flex items-start justify-between gap-4">
-        <div className="flex-1">
-          <p className="font-semibold">{PREBOWL.name}</p>
-          <p className="text-sm text-neutral-600">{PREBOWL.desc}</p>
-          {st === "low" && (
-            <span className="badge badge-warn mt-2 inline-block">
-              Pocas unidades
-            </span>
-          )}
+      <div className="card p-4 relative">
+        <div className="flex items-start justify-between gap-4 pb-14 pr-4">
+          <div className="flex-1">
+            <p className="font-semibold">{PREBOWL.name}</p>
+            <p className="text-sm text-neutral-600">{PREBOWL.desc}</p>
+            {st === "low" && (
+              <span className="badge badge-warn mt-2 inline-block">
+                Pocas unidades
+              </span>
+            )}
+          </div>
+          <div className="text-right shrink-0">
+            <p className="font-bold">${COP(PREBOWL.price)}</p>
+            {disabled && (
+              <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+            )}
+          </div>
         </div>
-        <div className="text-right shrink-0">
-          <p className="font-bold">${COP(PREBOWL.price)}</p>
-          <AddButton className="mt-1" onClick={addPre} disabled={disabled} />
-          {disabled && (
-            <p className="mt-1 text-sm text-neutral-500">Agotado</p>
-          )}
-        </div>
+        <AddButton
+          className="absolute bottom-4 right-4"
+          onClick={addPre}
+          disabled={disabled}
+        />
       </div>
 
       {/* Modal de armado */}

--- a/src/components/Buttons.jsx
+++ b/src/components/Buttons.jsx
@@ -34,11 +34,11 @@ export function AddButton({
       onClick={onClick}
       className={[
         "inline-flex items-center justify-center gap-2 rounded-full font-semibold shadow-sm transition select-none",
-        "bg-emerald-700 text-white hover:bg-emerald-800",
-        "border border-emerald-800/10",
-        "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-300",
-        "px-4 h-11 w-full sm:w-auto sm:h-10",
-        "active:translate-y-px",
+        "bg-[#2f4131] text-white hover:bg-[#243326]",
+        "border border-black/10",
+        "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgba(47,65,49,0.3)]",
+        "px-3 min-w-[112px] h-10 sm:h-9 w-auto",
+        "active:translate-y-[1px]",
         "disabled:bg-neutral-200 disabled:text-neutral-500 disabled:cursor-not-allowed",
         className,
       ].join(" ")}

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -279,8 +279,8 @@ export default function CoffeeSection() {
               (item.milkPolicy === "optional" && addMilk[item.id]);
 
             return (
-              <li key={item.id} className="card p-3">
-                <div className="flex items-start justify-between gap-4">
+              <li key={item.id} className="card p-3 relative">
+                <div className="flex items-start justify-between gap-4 pb-14 pr-4">
                   <div className="flex-1">
                     <p className="font-semibold">{displayName(item)}</p>
                     <p className="text-xs text-neutral-600">{item.desc}</p>
@@ -311,20 +311,20 @@ export default function CoffeeSection() {
                     </div>
                   </div>
 
-                  {/* Precio y añadir */}
+                  {/* Precio */}
                   <div className="text-right shrink-0">
                     <p className="text-xs text-neutral-500">Precio</p>
                     <p className="font-semibold">${COP(finalPrice(item))}</p>
-                    <AddButton
-                      className="mt-1"
-                      onClick={() => addToCart(item)}
-                      disabled={disabled}
-                    />
                     {disabled && (
                       <p className="mt-1 text-sm text-neutral-500">Agotado</p>
                     )}
                   </div>
                 </div>
+                <AddButton
+                  className="absolute bottom-4 right-4"
+                  onClick={() => addToCart(item)}
+                  disabled={disabled}
+                />
               </li>
             );
           })}
@@ -344,8 +344,8 @@ export default function CoffeeSection() {
             const showChaiMilk = isChai && modeOf(item.id) === "latte";
 
             return (
-              <li key={item.id} className="card p-3">
-                <div className="flex items-start justify-between gap-4">
+              <li key={item.id} className="card p-3 relative">
+                <div className="flex items-start justify-between gap-4 pb-14 pr-4">
                   <div className="flex-1">
                     <p className="font-semibold">{displayName(item)}</p>
                     <p className="text-xs text-neutral-600">{item.desc}</p>
@@ -366,16 +366,16 @@ export default function CoffeeSection() {
                   <div className="text-right shrink-0">
                     <p className="text-xs text-neutral-500">Precio</p>
                     <p className="font-semibold">${COP(finalPrice(item))}</p>
-                    <AddButton
-                      className="mt-1"
-                      onClick={() => addToCart(item)}
-                      disabled={disabled}
-                    />
                     {disabled && (
                       <p className="mt-1 text-sm text-neutral-500">Agotado</p>
                     )}
                   </div>
                 </div>
+                <AddButton
+                  className="absolute bottom-4 right-4"
+                  onClick={() => addToCart(item)}
+                  disabled={disabled}
+                />
               </li>
             );
           })}

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -169,21 +169,28 @@ export function Desserts() {
               <div
                 key={s.id}
                 className={
-                  "rounded-lg border px-3 py-2 " +
+                  "rounded-lg border px-3 py-2 relative " +
                   (disabled ? "opacity-60" : "")
                 }
               >
-                <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm">{s.label}</span>
-                    {st === "low" && (
-                      <span className="badge badge-warn">Pocas unidades</span>
-                    )}
+                <div className="pb-14 pr-4">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm">{s.label}</span>
+                      {st === "low" && (
+                        <span className="badge badge-warn">Pocas unidades</span>
+                      )}
+                    </div>
+                    <div className="text-right">
+                      <span className="font-semibold">${COP(price)}</span>
+                      {disabled && (
+                        <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+                      )}
+                    </div>
                   </div>
-                  <span className="font-semibold">${COP(price)}</span>
                 </div>
                 <AddButton
-                  className="mt-2"
+                  className="absolute bottom-4 right-4"
                   onClick={() =>
                     addItem({
                       productId: "cumbre",
@@ -194,9 +201,6 @@ export function Desserts() {
                   }
                   disabled={disabled}
                 />
-                {disabled && (
-                  <p className="mt-1 text-sm text-neutral-500">Agotado</p>
-                )}
               </div>
             );
           })}
@@ -228,29 +232,31 @@ function ProductRow({ item }) {
   const st = stateFor(item.id);
   const disabled = st === "out";
   return (
-    <li className="card p-3 flex items-start justify-between gap-4">
-      <div className="flex-1">
-        <p className="font-semibold">{item.name}</p>
-        <p className="text-sm text-neutral-600">{item.desc}</p>
-        {st === "low" && (
-          <span className="badge badge-warn mt-2 inline-block">
-            Pocas unidades
-          </span>
-        )}
+    <li className="card p-3 relative">
+      <div className="flex items-start justify-between gap-4 pb-14 pr-4">
+        <div className="flex-1">
+          <p className="font-semibold">{item.name}</p>
+          <p className="text-sm text-neutral-600">{item.desc}</p>
+          {st === "low" && (
+            <span className="badge badge-warn mt-2 inline-block">
+              Pocas unidades
+            </span>
+          )}
+        </div>
+        <div className="text-right shrink-0">
+          <p className="font-semibold">${COP(item.price)}</p>
+          {disabled && (
+            <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+          )}
+        </div>
       </div>
-      <div className="text-right shrink-0">
-        <p className="font-semibold">${COP(item.price)}</p>
-        <AddButton
-          className="mt-1"
-          onClick={() =>
-            addItem({ productId: item.id, name: item.name, price: item.price })
-          }
-          disabled={disabled}
-        />
-        {disabled && (
-          <p className="mt-1 text-sm text-neutral-500">Agotado</p>
-        )}
-      </div>
+      <AddButton
+        className="absolute bottom-4 right-4"
+        onClick={() =>
+          addItem({ productId: item.id, name: item.name, price: item.price })
+        }
+        disabled={disabled}
+      />
     </li>
   );
 }

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -104,35 +104,34 @@ export default function Sandwiches() {
           const st = stateFor(productId); // 'ok' | 'low' | 'out'
           const disabled = st === "out";
           return (
-            <li
-              key={it.key}
-              className="card p-3 flex items-start justify-between gap-4"
-            >
-              <div className="flex-1">
-                <p className="font-semibold">{it.name}</p>
-                <p className="text-sm text-neutral-600">{it.desc}</p>
-                {st === "low" && (
-                  <span className="badge badge-warn mt-2 inline-block">
-                    Pocas unidades
-                  </span>
-                )}
+            <li key={it.key} className="card p-3 relative">
+              <div className="flex items-start justify-between gap-4 pb-14 pr-4">
+                <div className="flex-1">
+                  <p className="font-semibold">{it.name}</p>
+                  <p className="text-sm text-neutral-600">{it.desc}</p>
+                  {st === "low" && (
+                    <span className="badge badge-warn mt-2 inline-block">
+                      Pocas unidades
+                    </span>
+                  )}
+                </div>
+                <div className="text-right shrink-0">
+                  <p className="font-semibold">${COP(priceFor(it.key))}</p>
+                  {disabled && (
+                    <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+                  )}
+                  {priceByItem[it.key].unico && (
+                    <p className="text-[11px] text-neutral-500 mt-1">
+                      Precio único
+                    </p>
+                  )}
+                </div>
               </div>
-              <div className="text-right shrink-0">
-                <p className="font-semibold">${COP(priceFor(it.key))}</p>
-                <AddButton
-                  className="mt-1"
-                  onClick={() => add(it)}
-                  disabled={disabled}
-                />
-                {disabled && (
-                  <p className="mt-1 text-sm text-neutral-500">Agotado</p>
-                )}
-                {priceByItem[it.key].unico && (
-                  <p className="text-[11px] text-neutral-500 mt-1">
-                    Precio único
-                  </p>
-                )}
-              </div>
+              <AddButton
+                className="absolute bottom-4 right-4"
+                onClick={() => add(it)}
+                disabled={disabled}
+              />
             </li>
           );
         })}

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -51,30 +51,29 @@ function List({ items, onAdd }) {
         const st = stateFor(id);
         const disabled = st === "out";
         return (
-          <li
-            key={p.name}
-            className="card p-3 flex items-start justify-between gap-4"
-          >
-            <div className="flex-1">
-              <p className="font-semibold">{p.name}</p>
-              <p className="text-sm text-neutral-600">{p.desc}</p>
-              {st === "low" && (
-                <span className="badge badge-warn mt-2 inline-block">
-                  Pocas unidades
-                </span>
-              )}
+          <li key={p.name} className="card p-3 relative">
+            <div className="flex items-start justify-between gap-4 pb-14 pr-4">
+              <div className="flex-1">
+                <p className="font-semibold">{p.name}</p>
+                <p className="text-sm text-neutral-600">{p.desc}</p>
+                {st === "low" && (
+                  <span className="badge badge-warn mt-2 inline-block">
+                    Pocas unidades
+                  </span>
+                )}
+              </div>
+              <div className="text-right shrink-0">
+                <p className="font-semibold">${COP(p.price)}</p>
+                {disabled && (
+                  <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+                )}
+              </div>
             </div>
-            <div className="text-right shrink-0">
-              <p className="font-semibold">${COP(p.price)}</p>
-              <AddButton
-                className="mt-1"
-                onClick={() => onAdd(p)}
-                disabled={disabled}
-              />
-              {disabled && (
-                <p className="mt-1 text-sm text-neutral-500">Agotado</p>
-              )}
-            </div>
+            <AddButton
+              className="absolute bottom-4 right-4"
+              onClick={() => onAdd(p)}
+              disabled={disabled}
+            />
           </li>
         );
       })}


### PR DESCRIPTION
## Summary
- add compact AddButton with brand colors and focus styles
- position AddButton in bottom-right of product cards with extra padding for content

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6b421c81c832782a904d35754dc1c