### PR TITLE
feat: convert add buttons to icon FAB

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
-import { AddButton } from "./Buttons";
+import { AddIconButton } from "./Buttons";
 import BowlBuilderModal from "./BowlBuilderModal";
 import stock from "../data/stock.json";
 
@@ -76,7 +76,7 @@ export default function BowlsSection() {
 
       {/* Card del prearmado */}
       <div className="card p-4 relative">
-        <div className="flex items-start justify-between gap-4 pb-14 pr-4">
+        <div className="flex items-start justify-between gap-4 pb-6 pr-4">
           <div className="flex-1">
             <p className="font-semibold">{PREBOWL.name}</p>
             <p className="text-sm text-neutral-600">{PREBOWL.desc}</p>
@@ -93,7 +93,7 @@ export default function BowlsSection() {
             )}
           </div>
         </div>
-        <AddButton
+        <AddIconButton
           className="absolute bottom-4 right-4"
           onClick={addPre}
           disabled={disabled}

--- a/src/components/Buttons.jsx
+++ b/src/components/Buttons.jsx
@@ -60,4 +60,28 @@ export function AddButton({
   );
 }
 
+export function AddIconButton({ onClick, disabled, className = "", type = "button", ariaLabel = "Añadir" }) {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      className={[
+        "grid place-items-center rounded-full shadow-sm border select-none transition",
+        "bg-[#2f4131] text-white hover:bg-[#243326] border-black/10",
+        "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgba(47,65,49,0.3)]",
+        "h-11 w-11 sm:h-10 sm:w-10",
+        "active:translate-y-[1px]",
+        "disabled:bg-neutral-200 disabled:text-neutral-500 disabled:border-neutral-200 disabled:cursor-not-allowed",
+        className,
+      ].join(" ")}
+    >
+      <svg viewBox="0 0 24 24" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d="M12 5v14M5 12h14" />
+      </svg>
+    </button>
+  );
+}
+
 export default AddButton;

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { AddButton } from "./Buttons";
+import { AddIconButton } from "./Buttons";
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
 import stock from "../data/stock.json";
@@ -280,7 +280,7 @@ export default function CoffeeSection() {
 
             return (
               <li key={item.id} className="card p-3 relative">
-                <div className="flex items-start justify-between gap-4 pb-14 pr-4">
+                <div className="flex items-start justify-between gap-4 pb-6 pr-4">
                   <div className="flex-1">
                     <p className="font-semibold">{displayName(item)}</p>
                     <p className="text-xs text-neutral-600">{item.desc}</p>
@@ -320,7 +320,7 @@ export default function CoffeeSection() {
                     )}
                   </div>
                 </div>
-                <AddButton
+                <AddIconButton
                   className="absolute bottom-4 right-4"
                   onClick={() => addToCart(item)}
                   disabled={disabled}
@@ -345,7 +345,7 @@ export default function CoffeeSection() {
 
             return (
               <li key={item.id} className="card p-3 relative">
-                <div className="flex items-start justify-between gap-4 pb-14 pr-4">
+                <div className="flex items-start justify-between gap-4 pb-6 pr-4">
                   <div className="flex-1">
                     <p className="font-semibold">{displayName(item)}</p>
                     <p className="text-xs text-neutral-600">{item.desc}</p>
@@ -371,7 +371,7 @@ export default function CoffeeSection() {
                     )}
                   </div>
                 </div>
-                <AddButton
+                <AddIconButton
                   className="absolute bottom-4 right-4"
                   onClick={() => addToCart(item)}
                   disabled={disabled}

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -1,7 +1,7 @@
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
 import stock from "../data/stock.json"; // ← sin assert
-import { AddButton } from "./Buttons";
+import { AddIconButton } from "./Buttons";
 
 // estado global: 'ok' | 'low' | 'out'
 function stateFor(productId) {
@@ -173,7 +173,7 @@ export function Desserts() {
                   (disabled ? "opacity-60" : "")
                 }
               >
-                <div className="pb-14 pr-4">
+                <div className="pb-6 pr-4">
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-2">
                       <span className="text-sm">{s.label}</span>
@@ -189,7 +189,7 @@ export function Desserts() {
                     </div>
                   </div>
                 </div>
-                <AddButton
+                <AddIconButton
                   className="absolute bottom-4 right-4"
                   onClick={() =>
                     addItem({
@@ -232,9 +232,9 @@ function ProductRow({ item }) {
   const st = stateFor(item.id);
   const disabled = st === "out";
   return (
-    <li className="card p-3">
+    <li className="card p-3 relative">
       <div className="flex items-start justify-between gap-4">
-        <div className="flex-1">
+        <div className="flex-1 pb-6 pr-4">
           <p className="font-semibold">{item.name}</p>
           <p className="text-xs text-neutral-600 mt-1">{item.desc}</p>
           {st === "low" && (
@@ -243,35 +243,20 @@ function ProductRow({ item }) {
             </span>
           )}
         </div>
-        <div className="flex items-start shrink-0">
-          <div className="text-right">
-            <p className="font-semibold">${COP(item.price)}</p>
-            {disabled && (
-              <p className="mt-1 text-sm text-neutral-500">Agotado</p>
-            )}
-          </div>
-          <AddButton
-            className="ml-4 self-start"
-            onClick={() =>
-              addItem({
-                productId: item.id,
-                name: item.name,
-                price: item.price,
-              })
-            }
-            disabled={disabled}
-          />
+        <div className="text-right">
+          <p className="font-semibold">${COP(item.price)}</p>
+          {disabled && (
+            <p className="mt-1 text-sm text-neutral-500">Agotado</p>
+          )}
         </div>
       </div>
-      <AddButton
-        hideText
+      <AddIconButton
         className="absolute bottom-4 right-4"
         onClick={() =>
           addItem({ productId: item.id, name: item.name, price: item.price })
         }
         disabled={disabled}
       />
-
     </li>
   );
 }

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Chip, AddButton } from "./Buttons";
+import { Chip, AddIconButton } from "./Buttons";
 import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 import stock from "../data/stock.json"; // ← sin assert
@@ -105,7 +105,7 @@ export default function Sandwiches() {
           const disabled = st === "out";
           return (
             <li key={it.key} className="card p-3 relative">
-              <div className="flex items-start justify-between gap-4 pb-14 pr-4">
+              <div className="flex items-start justify-between gap-4 pb-6 pr-4">
                 <div className="flex-1">
                   <p className="font-semibold">{it.name}</p>
                   <p className="text-sm text-neutral-600">{it.desc}</p>
@@ -127,7 +127,7 @@ export default function Sandwiches() {
                   )}
                 </div>
               </div>
-              <AddButton
+              <AddIconButton
                 className="absolute bottom-4 right-4"
                 onClick={() => add(it)}
                 disabled={disabled}

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -1,4 +1,4 @@
-import { AddButton } from "./Buttons";
+import { AddIconButton } from "./Buttons";
 import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 import stock from "../data/stock.json";
@@ -52,7 +52,7 @@ function List({ items, onAdd }) {
         const disabled = st === "out";
         return (
           <li key={p.name} className="card p-3 relative">
-            <div className="flex items-start justify-between gap-4 pb-14 pr-4">
+            <div className="flex items-start justify-between gap-4 pb-6 pr-4">
               <div className="flex-1">
                 <p className="font-semibold">{p.name}</p>
                 <p className="text-sm text-neutral-600">{p.desc}</p>
@@ -69,7 +69,7 @@ function List({ items, onAdd }) {
                 )}
               </div>
             </div>
-            <AddButton
+            <AddIconButton
               className="absolute bottom-4 right-4"
               onClick={() => onAdd(p)}
               disabled={disabled}


### PR DESCRIPTION
## Summary
- add reusable AddIconButton component
- switch product cards to new icon-only FAB and adjust layout spacing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a745f1d91c83278aaffd544ff36874