### PR TITLE
feat: unify product layout and status chips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "alto-andino-qr-menu",
       "version": "1.0.0",
       "dependencies": {
+        "clsx": "^1.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-qr-code": "2.0.18"
@@ -1421,6 +1422,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "clsx": "^1.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-qr-code": "2.0.18"

--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
-import { AddIconButton } from "./Buttons";
+import { AddIconButton, StatusChip } from "./Buttons";
 import BowlBuilderModal from "./BowlBuilderModal";
 import stock from "../data/stock.json";
 
@@ -75,26 +75,23 @@ export default function BowlsSection() {
       </button>
 
       {/* Card del prearmado */}
-      <div className="card p-4 relative">
-        <div className="flex items-start justify-between gap-4 pb-6 pr-4">
-          <div className="flex-1">
-            <p className="font-semibold">{PREBOWL.name}</p>
-            <p className="text-sm text-neutral-600">{PREBOWL.desc}</p>
-            {st === "low" && (
-              <span className="badge badge-warn mt-2 inline-block">
-                Pocas unidades
-              </span>
-            )}
-          </div>
-          <div className="text-right shrink-0">
-            <p className="font-bold">${COP(PREBOWL.price)}</p>
-            {disabled && (
-              <span className="badge badge-out mt-2 inline-block">Agotado</span>
-            )}
-          </div>
+      <div className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12">
+        <p className="font-semibold">{PREBOWL.name}</p>
+        <p className="text-sm text-neutral-600">{PREBOWL.desc}</p>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {st === "low" && (
+            <StatusChip variant="low">Pocas unidades</StatusChip>
+          )}
+          {disabled && (
+            <StatusChip variant="soldout">Agotado</StatusChip>
+          )}
+        </div>
+        <div className="absolute top-5 right-5 z-10 text-neutral-800 font-bold">
+          ${COP(PREBOWL.price)}
         </div>
         <AddIconButton
-          className="absolute bottom-4 right-4"
+          className="absolute bottom-4 right-4 z-20"
+          aria-label={"Añadir " + PREBOWL.name}
           onClick={addPre}
           disabled={disabled}
         />

--- a/src/components/Buttons.jsx
+++ b/src/components/Buttons.jsx
@@ -1,3 +1,5 @@
+import clsx from "clsx";
+
 export function Chip({ active, onClick, children, className = "" }) {
   return (
     <button
@@ -60,28 +62,47 @@ export function AddButton({
   );
 }
 
-export function AddIconButton({ onClick, disabled, className = "", type = "button", ariaLabel = "Añadir" }) {
+export function AddIconButton({ className = "", disabled = false, ...props }) {
   return (
     <button
-      type={type}
-      onClick={onClick}
+      type="button"
+      {...props}
       disabled={disabled}
-      aria-label={ariaLabel}
-      className={[
-        "grid place-items-center rounded-full shadow-sm border select-none transition",
-        "bg-[#2f4131] text-white hover:bg-[#243326] border-black/10",
-        "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgba(47,65,49,0.3)]",
-        "h-10 w-10 sm:h-9 sm:w-9",
-
-        "active:translate-y-[1px]",
-        "disabled:bg-neutral-200 disabled:text-neutral-500 disabled:border-neutral-200 disabled:cursor-not-allowed",
-        className,
-      ].join(" ")}
+      className={clsx(
+        // base shape & color
+        "grid place-items-center rounded-full bg-[#2f4131] text-white shadow-sm ring-1 ring-black/5",
+        // sizes
+        "w-9 h-9 sm:w-8 sm:h-8",
+        // motion & focus
+        "transition will-change-transform hover:scale-105 active:scale-95",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(47,65,49,0.3)] focus-visible:ring-offset-2",
+        // disabled
+        disabled && "opacity-40 pointer-events-none",
+        className
+      )}
     >
-      <svg viewBox="0 0 24 24" className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-        <path d="M12 5v14M5 12h14" />
-      </svg>
+      {/* Visual “+” y soporte de accesibilidad vía aria-label desde el padre */}
+      <span aria-hidden className="-mt-[1px] text-xl leading-none">+</span>
     </button>
+  );
+}
+
+export function StatusChip({ variant = "neutral", className = "", children }) {
+  const map = {
+    low: "bg-amber-50 text-amber-800 border-amber-300",
+    soldout: "bg-neutral-100 text-neutral-700 border-neutral-200",
+    neutral: "bg-neutral-100 text-neutral-700 border-neutral-200",
+  };
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center rounded-full border px-2 py-[3px] text-[11px] leading-none font-medium",
+        map[variant],
+        className
+      )}
+    >
+      {children}
+    </span>
   );
 }
 

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { AddIconButton } from "./Buttons";
+import { AddIconButton, StatusChip } from "./Buttons";
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
 import stock from "../data/stock.json";
@@ -279,49 +279,45 @@ export default function CoffeeSection() {
               (item.milkPolicy === "optional" && addMilk[item.id]);
 
             return (
-              <li key={item.id} className="card p-3 relative">
-                <div className="flex items-start justify-between gap-4 pb-6 pr-4">
-                  <div className="flex-1">
-                    <p className="font-semibold">{displayName(item)}</p>
-                    <p className="text-xs text-neutral-600">{item.desc}</p>
-
-                    {/* Controles contextuales */}
-                    <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2">
-                      {item.milkPolicy === "optional" && (
-                        <button
-                          className="text-xs text-alto-primary underline text-left"
-                          onClick={() => toggleAddMilk(item.id)}
-                        >
-                          {addMilk[item.id]
-                            ? "Quitar leche"
-                            : "+ Agregar leche"}
-                        </button>
-                      )}
-                      {item.id === "cof-espresso" && addMilk[item.id] && (
-                        <EspressoStyleSelect id={item.id} />
-                      )}
-                      {showMilkSelect && (
-                        <MilkSelect id={item.id} disabled={disabled} />
-                      )}
-                      {st === "low" && (
-                        <span className="badge badge-warn self-start">
-                          Pocas unidades
-                        </span>
-                      )}
-                    </div>
-                  </div>
-
-                  {/* Precio */}
-                  <div className="text-right shrink-0">
-                    <p className="text-xs text-neutral-500">Precio</p>
-                    <p className="font-semibold">${COP(finalPrice(item))}</p>
-                    {disabled && (
-                      <span className="badge badge-out mt-2 inline-block">Agotado</span>
-                    )}
-                  </div>
+              <li
+                key={item.id}
+                className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12"
+              >
+                <p className="font-semibold">{displayName(item)}</p>
+                <p className="text-xs text-neutral-600">{item.desc}</p>
+                {/* Controles contextuales */}
+                <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2">
+                  {item.milkPolicy === "optional" && (
+                    <button
+                      className="text-xs text-alto-primary underline text-left"
+                      onClick={() => toggleAddMilk(item.id)}
+                    >
+                      {addMilk[item.id]
+                        ? "Quitar leche"
+                        : "+ Agregar leche"}
+                    </button>
+                  )}
+                  {item.id === "cof-espresso" && addMilk[item.id] && (
+                    <EspressoStyleSelect id={item.id} />
+                  )}
+                  {showMilkSelect && (
+                    <MilkSelect id={item.id} disabled={disabled} />
+                  )}
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {st === "low" && (
+                    <StatusChip variant="low">Pocas unidades</StatusChip>
+                  )}
+                  {disabled && (
+                    <StatusChip variant="soldout">Agotado</StatusChip>
+                  )}
+                </div>
+                <div className="absolute top-5 right-5 z-10 text-neutral-800 font-semibold">
+                  ${COP(finalPrice(item))}
                 </div>
                 <AddIconButton
-                  className="absolute bottom-4 right-4"
+                  className="absolute bottom-4 right-4 z-20"
+                  aria-label={"Añadir " + displayName(item)}
                   onClick={() => addToCart(item)}
                   disabled={disabled}
                 />
@@ -344,35 +340,32 @@ export default function CoffeeSection() {
             const showChaiMilk = isChai && modeOf(item.id) === "latte";
 
             return (
-              <li key={item.id} className="card p-3 relative">
-                <div className="flex items-start justify-between gap-4 pb-6 pr-4">
-                  <div className="flex-1">
-                    <p className="font-semibold">{displayName(item)}</p>
-                    <p className="text-xs text-neutral-600">{item.desc}</p>
-
-                    <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2">
-                      {isChai && <ChaiModeSelect id={item.id} />}
-                      {showChaiMilk && (
-                        <MilkSelect id={item.id} disabled={disabled} />
-                      )}
-                      {st === "low" && (
-                        <span className="badge badge-warn self-start">
-                          Pocas unidades
-                        </span>
-                      )}
-                    </div>
-                  </div>
-
-                  <div className="text-right shrink-0">
-                    <p className="text-xs text-neutral-500">Precio</p>
-                    <p className="font-semibold">${COP(finalPrice(item))}</p>
-                    {disabled && (
-                      <span className="badge badge-out mt-2 inline-block">Agotado</span>
-                    )}
-                  </div>
+              <li
+                key={item.id}
+                className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12"
+              >
+                <p className="font-semibold">{displayName(item)}</p>
+                <p className="text-xs text-neutral-600">{item.desc}</p>
+                <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2">
+                  {isChai && <ChaiModeSelect id={item.id} />}
+                  {showChaiMilk && (
+                    <MilkSelect id={item.id} disabled={disabled} />
+                  )}
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {st === "low" && (
+                    <StatusChip variant="low">Pocas unidades</StatusChip>
+                  )}
+                  {disabled && (
+                    <StatusChip variant="soldout">Agotado</StatusChip>
+                  )}
+                </div>
+                <div className="absolute top-5 right-5 z-10 text-neutral-800 font-semibold">
+                  ${COP(finalPrice(item))}
                 </div>
                 <AddIconButton
-                  className="absolute bottom-4 right-4"
+                  className="absolute bottom-4 right-4 z-20"
+                  aria-label={"Añadir " + displayName(item)}
                   onClick={() => addToCart(item)}
                   disabled={disabled}
                 />

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -1,7 +1,7 @@
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
 import stock from "../data/stock.json"; // ← sin assert
-import { AddIconButton } from "./Buttons";
+import { AddIconButton, StatusChip } from "./Buttons";
 
 // estado global: 'ok' | 'low' | 'out'
 function stateFor(productId) {
@@ -149,13 +149,13 @@ export function Desserts() {
   return (
     <div className="space-y-4">
       {/* Cumbre Andino con precio por sabor */}
-      <div className="card p-3">
+      <div className="rounded-2xl p-5 sm:p-6 shadow-sm bg-white">
         <p className="font-semibold">Cumbre Andino (sin azúcar)</p>
         <p className="text-xs text-neutral-600 mt-1">
           Yogur griego endulzado con alulosa, mermelada natural, galleta sin
           azúcar, chantilly con eritritol y fruta.
         </p>
-        <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-2">
           {cumbreSabores.map((s) => {
             const st =
               cumbreStock[s.id] === "low"
@@ -169,28 +169,25 @@ export function Desserts() {
               <div
                 key={s.id}
                 className={
-                  "rounded-lg border px-3 py-2 relative " +
+                  "relative rounded-xl border border-neutral-200/60 bg-white p-4 sm:p-5 pr-20 pb-12 " +
                   (disabled ? "opacity-60" : "")
                 }
               >
-                <div className="pb-6 pr-4">
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm">{s.label}</span>
-                      {st === "low" && (
-                        <span className="badge badge-warn">Pocas unidades</span>
-                      )}
-                    </div>
-                    <div className="text-right">
-                      <span className="font-semibold">${COP(price)}</span>
-                      {disabled && (
-                        <span className="badge badge-out mt-2 inline-block">Agotado</span>
-                      )}
-                    </div>
-                  </div>
+                <p className="text-sm">{s.label}</p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {st === "low" && (
+                    <StatusChip variant="low">Pocas unidades</StatusChip>
+                  )}
+                  {disabled && (
+                    <StatusChip variant="soldout">Agotado</StatusChip>
+                  )}
+                </div>
+                <div className="absolute top-5 right-5 z-10 text-neutral-800 font-semibold">
+                  ${COP(price)}
                 </div>
                 <AddIconButton
-                  className="absolute bottom-4 right-4"
+                  className="absolute bottom-4 right-4 z-20"
+                  aria-label={"Añadir Cumbre Andino " + s.label}
                   onClick={() =>
                     addItem({
                       productId: "cumbre",
@@ -232,28 +229,23 @@ function ProductRow({ item }) {
   const st = stateFor(item.id);
   const disabled = st === "out";
   return (
-    <li className="card p-3 relative">
-      <div className="flex items-start justify-between gap-4 pb-6 pr-4">
-        <div className="flex-1">
-
-          <p className="font-semibold">{item.name}</p>
-          <p className="text-xs text-neutral-600 mt-1">{item.desc}</p>
-          {st === "low" && (
-            <span className="badge badge-warn mt-2 inline-block">
-              Pocas unidades
-            </span>
-          )}
-        </div>
-        <div className="text-right">
-          <p className="font-semibold">${COP(item.price)}</p>
-          {disabled && (
-            <span className="badge badge-out mt-2 inline-block">Agotado</span>
-
-          )}
-        </div>
+    <li className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12">
+      <p className="font-semibold">{item.name}</p>
+      <p className="text-xs text-neutral-600 mt-1">{item.desc}</p>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {st === "low" && (
+          <StatusChip variant="low">Pocas unidades</StatusChip>
+        )}
+        {disabled && (
+          <StatusChip variant="soldout">Agotado</StatusChip>
+        )}
+      </div>
+      <div className="absolute top-5 right-5 z-10 text-neutral-800 font-semibold">
+        ${COP(item.price)}
       </div>
       <AddIconButton
-        className="absolute bottom-4 right-4"
+        className="absolute bottom-4 right-4 z-20"
+        aria-label={"Añadir " + item.name}
         onClick={() =>
           addItem({ productId: item.id, name: item.name, price: item.price })
         }

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Chip, AddIconButton } from "./Buttons";
+import { Chip, AddIconButton, StatusChip } from "./Buttons";
 import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 import stock from "../data/stock.json"; // ← sin assert
@@ -104,31 +104,31 @@ export default function Sandwiches() {
           const st = stateFor(productId); // 'ok' | 'low' | 'out'
           const disabled = st === "out";
           return (
-            <li key={it.key} className="card p-3 relative">
-              <div className="flex items-start justify-between gap-4 pb-6 pr-4">
-                <div className="flex-1">
-                  <p className="font-semibold">{it.name}</p>
-                  <p className="text-sm text-neutral-600">{it.desc}</p>
-                  {st === "low" && (
-                    <span className="badge badge-warn mt-2 inline-block">
-                      Pocas unidades
-                    </span>
-                  )}
-                </div>
-                <div className="text-right shrink-0">
-                  <p className="font-semibold">${COP(priceFor(it.key))}</p>
-                  {disabled && (
-                    <span className="badge badge-out mt-2 inline-block">Agotado</span>
-                  )}
-                  {priceByItem[it.key].unico && (
-                    <p className="text-[11px] text-neutral-500 mt-1">
-                      Precio único
-                    </p>
-                  )}
-                </div>
+            <li
+              key={it.key}
+              className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12"
+            >
+              <p className="font-semibold">{it.name}</p>
+              <p className="text-sm text-neutral-600">{it.desc}</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {st === "low" && (
+                  <StatusChip variant="low">Pocas unidades</StatusChip>
+                )}
+                {disabled && (
+                  <StatusChip variant="soldout">Agotado</StatusChip>
+                )}
+                {priceByItem[it.key].unico && (
+                  <span className="text-[11px] text-neutral-500">
+                    Precio único
+                  </span>
+                )}
+              </div>
+              <div className="absolute top-5 right-5 z-10 text-neutral-800 font-semibold">
+                ${COP(priceFor(it.key))}
               </div>
               <AddIconButton
-                className="absolute bottom-4 right-4"
+                className="absolute bottom-4 right-4 z-20"
+                aria-label={"Añadir " + it.name}
                 onClick={() => add(it)}
                 disabled={disabled}
               />

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -1,4 +1,4 @@
-import { AddIconButton } from "./Buttons";
+import { AddIconButton, StatusChip } from "./Buttons";
 import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 import stock from "../data/stock.json";
@@ -51,26 +51,26 @@ function List({ items, onAdd }) {
         const st = stateFor(id);
         const disabled = st === "out";
         return (
-          <li key={p.name} className="card p-3 relative">
-            <div className="flex items-start justify-between gap-4 pb-6 pr-4">
-              <div className="flex-1">
-                <p className="font-semibold">{p.name}</p>
-                <p className="text-sm text-neutral-600">{p.desc}</p>
-                {st === "low" && (
-                  <span className="badge badge-warn mt-2 inline-block">
-                    Pocas unidades
-                  </span>
-                )}
-              </div>
-              <div className="text-right shrink-0">
-                <p className="font-semibold">${COP(p.price)}</p>
-                {disabled && (
-                  <span className="badge badge-out mt-2 inline-block">Agotado</span>
-                )}
-              </div>
+          <li
+            key={p.name}
+            className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12"
+          >
+            <p className="font-semibold">{p.name}</p>
+            <p className="text-sm text-neutral-600">{p.desc}</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {st === "low" && (
+                <StatusChip variant="low">Pocas unidades</StatusChip>
+              )}
+              {disabled && (
+                <StatusChip variant="soldout">Agotado</StatusChip>
+              )}
+            </div>
+            <div className="absolute top-5 right-5 z-10 text-neutral-800 font-semibold">
+              ${COP(p.price)}
             </div>
             <AddIconButton
-              className="absolute bottom-4 right-4"
+              className="absolute bottom-4 right-4 z-20"
+              aria-label={"Añadir " + p.name}
               onClick={() => onAdd(p)}
               disabled={disabled}
             />


### PR DESCRIPTION
## Summary
- standardize FAB and status badges across menu items
- apply consistent card layout with absolute price and floating add button
- add StatusChip component and unify AddIconButton sizing

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a74cf581888327a43cf050085b4c65