### PR TITLE
feat: chip-style milk selector and sandwich price label

### DIFF
--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -118,9 +118,7 @@ export default function Sandwiches() {
                   <StatusChip variant="soldout">Agotado</StatusChip>
                 )}
                 {priceByItem[it.key].unico && (
-                  <span className="text-[11px] text-neutral-500">
-                    Precio único
-                  </span>
+                  <StatusChip variant="neutral">Precio único</StatusChip>
                 )}
               </div>
               <div className="absolute top-5 right-5 z-10 text-neutral-800 font-semibold">


### PR DESCRIPTION
## Summary
- switch coffee milk selector to chip UI while keeping underlying select for logic
- hide milk options for Americano and update coffee descriptions with percentages
- show "Precio único" as neutral StatusChip on sandwiches

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a75b774f948327aaa58c9c413f20c7