### PR TITLE
feat: horizontal category bar and guide modal

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+// util para slug simple desde el título de la sección
+const slugify = (s) =>
+  s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+
+export default function CategoryBar() {
+  const [active, setActive] = useState(null);
+  const containerRef = useRef(null);
+
+  // Leer secciones del DOM (Section.jsx añadirá data-aa-section y id)
+  const sections = useMemo(() => {
+    const nodes = document.querySelectorAll("[data-aa-section]");
+    return Array.from(nodes).map((n) => ({
+      id: n.id || slugify(n.getAttribute("data-aa-section")),
+      label: n.getAttribute("data-aa-section"),
+      el: n,
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (!sections.length) return;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) setActive(e.target.id);
+        });
+      },
+      { rootMargin: "-48px 0px -60% 0px", threshold: 0.2 }
+    );
+    sections.forEach(({ el }) => obs.observe(el));
+    return () => obs.disconnect();
+  }, [sections]);
+
+  const scrollTo = (id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const stickyH = 56; // altura aprox de la barra
+    const y = el.getBoundingClientRect().top + window.scrollY - stickyH - 8;
+    window.scrollTo({ top: y, behavior: "smooth" });
+  };
+
+  return (
+    <div className="sticky top-0 z-40 bg-[rgba(250,247,242,0.9)] backdrop-blur border-b border-black/5">
+      <div
+        ref={containerRef}
+        className="max-w-3xl mx-auto px-4 py-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        <div className="flex gap-2">
+          {sections.map(({ id, label }) => (
+            <button
+              key={id}
+              onClick={() => scrollTo(id)}
+              aria-pressed={active === id}
+              className={[
+                "px-3 py-1 rounded-full text-sm border transition whitespace-nowrap",
+                active === id
+                  ? "bg-[#2f4131] text-white border-[#2f4131] shadow"
+                  : "bg-white text-neutral-800 border-neutral-300 hover:border-neutral-400",
+              ].join(" ")}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/DietaryGuide.jsx
+++ b/src/components/DietaryGuide.jsx
@@ -15,7 +15,7 @@ export default function DietaryGuide() {
   ];
   return (
     <div className="max-w-3xl mx-auto px-4 py-3 sm:py-4">
-      <h2 className="text-sm font-medium text-[#2f4131] mb-2">
+      <h2 className="text-base font-semibold text-[#2f4131] mb-2">
         Guía dietaria y alérgenos
       </h2>
       <div className="mt-2 grid grid-cols-2 sm:grid-cols-3 gap-2">

--- a/src/components/GuideModal.jsx
+++ b/src/components/GuideModal.jsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+
+export default function GuideModal({ open, onClose, children }) {
+  useEffect(() => {
+    const onKey = (e) => e.key === "Escape" && onClose?.();
+    if (open) document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center"
+      aria-modal="true"
+      role="dialog"
+    >
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative max-w-md w-[92%] rounded-2xl bg-[#FAF7F2] p-5 shadow-lg">
+        <button
+          onClick={onClose}
+          aria-label="Cerrar"
+          className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+        >×</button>
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+}
+

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,8 @@
 // src/components/Header.jsx
 import React, { useState } from "react";
 import { getTableId } from "../utils/table";
+import CategoryBar from "./CategoryBar";
+import GuideModal from "./GuideModal";
 import DietaryGuide from "./DietaryGuide";
 
 const IG_URL =
@@ -63,30 +65,20 @@ export default function Header() {
         </div>
       </header>
 
-      <div className="sticky top-0 z-40 bg-[rgba(250,247,242,0.9)] backdrop-blur border-b border-black/5">
-        <div className="max-w-3xl mx-auto px-4 py-2 flex items-center justify-between">
-          <div className="font-semibold text-[#2f4131] text-base sm:text-lg">
-            Alto Andino Delicatessen
-          </div>
-          <button
-            type="button"
-            aria-expanded={openGuide}
-            onClick={() => setOpenGuide((v) => !v)}
-            className="text-[#2f4131] text-sm font-medium underline decoration-[#2f4131]/40 hover:decoration-[#2f4131] focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)] rounded px-1"
-          >
-            Guía dietaria y alérgenos
-          </button>
-        </div>
-      </div>
-      <div
-        data-open={openGuide ? "true" : "false"}
-        className={[
-          "overflow-hidden transition-[max-height,opacity] duration-300 ease-out",
-          openGuide ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0",
-        ].join(" ")}
+      <CategoryBar />
+
+      <button
+        onClick={() => setOpenGuide(true)}
+        className="fixed bottom-20 right-4 z-40 grid h-12 w-12 place-items-center rounded-full bg-[#2f4131] text-white shadow-lg ring-1 ring-black/5 hover:scale-105 active:scale-95 transition focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+        aria-label="Guía dietaria y alérgenos"
+        title="Guía dietaria y alérgenos"
       >
+        i
+      </button>
+
+      <GuideModal open={openGuide} onClose={() => setOpenGuide(false)}>
         <DietaryGuide />
-      </div>
+      </GuideModal>
     </>
   );
 }

--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -1,17 +1,20 @@
-// src/components/Section.jsx
-export default function Section({ title, id, className = "", children }) {
-  const sectionId =
-    id ||
-    title
-      ?.toLowerCase()
-      .replace(/\s+/g, "-")
-      .replace(/[^\w-]/g, "");
+import React from "react";
+
+export default function Section({ title, children }) {
+  const id = title
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
   return (
-    <section id={sectionId} className={`mt-8 sm:mt-10 ${className}`}>
-      <h2 className="inline-block text-xl sm:text-2xl font-extrabold tracking-tight text-alto-text mb-3 border-b-2 border-alto-primary/30">
+    <section id={id} data-aa-section={title} className="scroll-mt-20">
+      <h2 className="text-2xl font-extrabold text-neutral-900 flex items-end gap-3">
         {title}
+        <span className="h-[3px] w-14 bg-[#2f4131]/20 rounded-md translate-y-[8px]" />
       </h2>
-      <div className="space-y-4">{children}</div>
+      <div className="mt-3">{children}</div>
     </section>
   );
 }
+


### PR DESCRIPTION
## Summary
- add sticky horizontal category bar with smooth scroll and active chip highlighting
- move dietary guide to centered modal triggered by floating action button
- update sections with ids for chip navigation and accessible modal title

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a77c6fdb988327bf9b07885ec5e4a6