### PR TITLE
feat: refine guide button and category bar behavior

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -46,11 +46,18 @@ export default function CategoryBar() {
   };
 
   return (
-    <div className="sticky top-0 z-40 bg-[rgba(250,247,242,0.9)] backdrop-blur border-b border-black/5">
+    <div
+      className="sticky z-40 bg-[rgba(250,247,242,0.9)] backdrop-blur border-b border-black/5"
+      style={{ top: "env(safe-area-inset-top)" }}
+      aria-label="Categorías del menú"
+    >
       <div
         ref={containerRef}
-        className="max-w-3xl mx-auto px-4 py-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="max-w-3xl mx-auto px-4 py-2 overflow-x-auto min-h-[44px] [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden relative"
       >
+        {/* pistas de scroll a los lados */}
+        <span className="pointer-events-none absolute left-0 top-0 h-full w-6 bg-gradient-to-r from-[rgba(250,247,242,1)] to-[rgba(250,247,242,0)]" />
+        <span className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-[rgba(250,247,242,1)] to-[rgba(250,247,242,0)]" />
         <div className="flex gap-2">
           {sections.map(({ id, label }) => (
             <button

--- a/src/components/FloatingCartBar.jsx
+++ b/src/components/FloatingCartBar.jsx
@@ -2,7 +2,7 @@ import { COP } from "../utils/money";
 export default function FloatingCartBar({ count, total, onOpen }) {
   if (!count) return null;
   return (
-    <div className="fixed bottom-4 left-4 right-4 z-40">
+    <div data-aa-cartbar className="fixed bottom-4 left-4 right-4 z-40">
       <div className="flex items-center justify-between gap-3 rounded-2xl bg-alto-primary text-white shadow-lg px-4 py-3">
         <div className="text-sm">
           <span className="font-semibold">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,5 @@
 // src/components/Header.jsx
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { getTableId } from "../utils/table";
 import CategoryBar from "./CategoryBar";
 import GuideModal from "./GuideModal";
@@ -27,6 +27,21 @@ const WA_LINK = `https://wa.me/${WA_NUM}`;
 export default function Header() {
   const table = getTableId();
   const [openGuide, setOpenGuide] = useState(false);
+
+  // Calcula altura de la barra del carrito si existe y la expone en --aa-cartbar-h
+  useEffect(() => {
+    const el = document.querySelector("[data-aa-cartbar]");
+    const setVar = (h) =>
+      document.documentElement.style.setProperty("--aa-cartbar-h", `${h || 0}px`);
+    if (!el) {
+      setVar(0);
+      return;
+    }
+    const ro = new ResizeObserver(() => setVar(el.offsetHeight));
+    ro.observe(el);
+    setVar(el.offsetHeight);
+    return () => ro.disconnect();
+  }, []);
 
   return (
     <>
@@ -69,11 +84,23 @@ export default function Header() {
 
       <button
         onClick={() => setOpenGuide(true)}
-        className="fixed bottom-20 right-4 z-40 grid h-12 w-12 place-items-center rounded-full bg-[#2f4131] text-white shadow-lg ring-1 ring-black/5 hover:scale-105 active:scale-95 transition focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
         aria-label="Guía dietaria y alérgenos"
         title="Guía dietaria y alérgenos"
+        id="aa-guide-fab"
+        className={[
+          "fixed right-4 z-40",
+          "px-4 h-10 rounded-full",
+          "bg-[#2f4131] text-white shadow-lg ring-1 ring-black/5",
+          "hover:scale-105 active:scale-95 transition",
+          "focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]",
+        ].join(" ")}
+        // bottom dinámico via style; ver efecto más abajo
+        style={{
+          bottom:
+            "calc(env(safe-area-inset-bottom) + var(--aa-cartbar-h, 0px) + 1rem)",
+        }}
       >
-        i
+        Alérgenos
       </button>
 
       <GuideModal open={openGuide} onClose={() => setOpenGuide(false)}>


### PR DESCRIPTION
## Summary
- replace guide FAB with pill button and dynamic safe-area offset
- make category bar sticky on mobile with scroll cues
- expose cart bar height for offset calculations

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a77eee0ac083278907154431f8024e