### PR TITLE
refactor: full-bleed category bar and ghost allergen button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,40 +38,42 @@ export default function App() {
 
   // ✅ Modo menú normal
   return (
-    <div className="mx-auto max-w-3xl bg-alto-beige text-alto-text p-5 sm:p-6 md:p-8 leading-snug">
+    <div className="bg-alto-beige text-alto-text leading-snug">
       <Header />
 
-      <Section title="Desayunos">
-        <Breakfasts />
-      </Section>
-      <Section title="Bowls">
-        <BowlsSection />
-      </Section>
-      <Section title="Platos Fuertes">
-        <Mains />
-      </Section>
-      <Section title="Sándwiches">
-        <Sandwiches />
-      </Section>
-      <Section title="Smoothies & Funcionales">
-        <SmoothiesSection />
-      </Section>
-      <Section title="Café de especialidad">
-        <CoffeeSection />
-      </Section>
-      <Section title="Postres">
-        <Desserts />
-      </Section>
+      <div className="mx-auto max-w-3xl p-5 sm:p-6 md:p-8">
+        <Section title="Desayunos">
+          <Breakfasts />
+        </Section>
+        <Section title="Bowls">
+          <BowlsSection />
+        </Section>
+        <Section title="Platos Fuertes">
+          <Mains />
+        </Section>
+        <Section title="Sándwiches">
+          <Sandwiches />
+        </Section>
+        <Section title="Smoothies & Funcionales">
+          <SmoothiesSection />
+        </Section>
+        <Section title="Café de especialidad">
+          <CoffeeSection />
+        </Section>
+        <Section title="Postres">
+          <Desserts />
+        </Section>
 
-      <Footer />
+        <Footer />
 
-      {/* Barra flotante y Drawer del carrito */}
-      <FloatingCartBar
-        count={cart.count}
-        total={cart.total}
-        onOpen={() => setOpen(true)}
-      />
-      {open && <CartDrawer onClose={() => setOpen(false)} />}
+        {/* Barra flotante y Drawer del carrito */}
+        <FloatingCartBar
+          count={cart.count}
+          total={cart.total}
+          onOpen={() => setOpen(true)}
+        />
+        {open && <CartDrawer onClose={() => setOpen(false)} />}
+      </div>
     </div>
   );
 }

--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -77,7 +77,7 @@ export default function CategoryBar({ onOpenGuide }) {
                   "px-3 py-1 rounded-full text-sm border transition whitespace-nowrap",
                   active === id
                     ? "bg-[#2f4131] text-white border-[#2f4131] shadow"
-                    : "bg-white text-neutral-800 border-neutral-300 hover:border-neutral-400"
+                    : "bg-white text-neutral-800 border-neutral-300 hover:border-neutral-400",
                 ].join(" ")}
               >
                 {label}
@@ -90,8 +90,7 @@ export default function CategoryBar({ onOpenGuide }) {
         <button
           type="button"
           onClick={onOpenGuide}
-          className="shrink-0 px-3 h-9 rounded-full bg-[#2f4131] text-white shadow-sm ring-1 ring-black/5 hover:scale-105 active:scale-95 transition
-                   focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+          className="shrink-0 h-8 px-2.5 rounded-full text-xs border border-[#2f4131]/30 text-[#2f4131] bg-white/50 hover:bg-[#2f4131] hover:text-white hover:border-[#2f4131] shadow-sm ring-1 ring-black/5 transition focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
           aria-label="Guía dietaria y alérgenos"
         >
           Alérgenos

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -12,34 +12,35 @@ export default function Header() {
 
   return (
     <>
-      <header className="mb-6">
-        {/* Logo centrado y sin fondo */}
-        <div className="flex flex-col items-center text-center">
-          <img
-            src="/logoalto.png"
-            alt="Alto Andino Delicatessen"
-            className="h-20 sm:h-24 md:h-28 mx-auto object-contain drop-shadow-sm"
-          />
-          <p className="text-[11px] sm:text-xs text-neutral-600">
-            Ingredientes locales y de temporada · Pet Friendly
-          </p>
+      <div className="max-w-3xl mx-auto p-5 sm:p-6 md:p-8">
+        <header className="mb-6">
+          {/* Logo centrado y sin fondo */}
+          <div className="flex flex-col items-center text-center">
+            <img
+              src="/logoalto.png"
+              alt="Alto Andino Delicatessen"
+              className="h-20 sm:h-24 md:h-28 mx-auto object-contain drop-shadow-sm"
+            />
+            <p className="text-[11px] sm:text-xs text-neutral-600">
+              Ingredientes locales y de temporada · Pet Friendly
+            </p>
 
-          {/* ✅ Chip con la mesa (si existe en la URL o guardada) */}
-          {table && (
-            <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-emerald-100 text-emerald-800 px-3 py-1 text-xs font-semibold">
-              Mesa {table}
-            </span>
-          )}
-        </div>
+            {/* ✅ Chip con la mesa (si existe en la URL o guardada) */}
+            {table && (
+              <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-emerald-100 text-emerald-800 px-3 py-1 text-xs font-semibold">
+                Mesa {table}
+              </span>
+            )}
+          </div>
 
-        {/* Línea sutil y datos */}
-        <div className="mt-4 border-t border-neutral-200 pt-3">
-          <p className="text-center sm:text-left text-xs sm:text-sm text-neutral-700">
-
-            Carrera 15 # 1 – 111, San Pablo
-          </p>
-        </div>
-      </header>
+          {/* Línea sutil y datos */}
+          <div className="mt-4 border-t border-neutral-200 pt-3">
+            <p className="text-center sm:text-left text-xs sm:text-sm text-neutral-700">
+              Carrera 15 # 1 – 111, San Pablo
+            </p>
+          </div>
+        </header>
+      </div>
 
       <CategoryBar onOpenGuide={() => setOpenGuide(true)} />
 


### PR DESCRIPTION
## Summary
- style allergens button as small ghost chip
- let category bar span full width outside header container
- restructure layout for full-bleed category bar

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a786cc11b883279ed2cb4ccb69621b