### PR TITLE
feat: restyle bowl builder to brand palette

### DIFF
--- a/src/components/BowlBuilderModal.jsx
+++ b/src/components/BowlBuilderModal.jsx
@@ -12,10 +12,10 @@ function Tile({ active, disabled, onClick, children }) {
       disabled={disabled && !active}
       aria-pressed={active}
       className={
-        "w-full text-left rounded-xl border px-3 py-3 text-sm transition " +
+        "w-full text-left rounded-2xl px-4 py-3 text-sm transition ring-1 " +
         (active
-          ? "bg-alto-primary text-white border-alto-primary shadow"
-          : "bg-white text-neutral-900 border-neutral-300 hover:border-neutral-400") +
+          ? "bg-[#2f4131] text-white ring-[#2f4131] shadow-sm"
+          : "bg-white text-neutral-900 ring-neutral-200 hover:ring-neutral-300") +
         (disabled && !active ? " opacity-50 cursor-not-allowed" : "")
       }
     >
@@ -194,24 +194,24 @@ export default function BowlBuilderModal({ open, onClose }) {
       <div className="absolute inset-0 bg-black/50" />
 
       {/* Contenedor con scroll interno */}
-      <div className="relative w-full max-w-2xl max-h-[90vh] rounded-3xl overflow-hidden bg-alto-warmwhite shadow-2xl flex flex-col">
-        {/* Header naturaleza (mejor hover del botón Restablecer) */}
-        <div className="bg-gradient-to-br from-alto-primary via-emerald-600 to-green-700 text-white p-5">
+      <div className="relative w-full max-w-2xl max-h-[90vh] rounded-3xl overflow-hidden bg-[#FAF7F2] shadow-2xl flex flex-col">
+        {/* Header */}
+        <div className="rounded-t-2xl bg-[#2f4131] text-white p-5">
           <div className="flex items-start justify-between gap-3">
             <div>
-              <h3 className="text-lg font-bold">Arma tu bowl</h3>
-              <p className="text-xs opacity-90">
+              <h3 className="text-white font-semibold text-lg">Arma tu bowl</h3>
+              <p className="text-white/90 text-sm">
                 1 base, 1 proteína, 4 toppings, 3 extras y 1 salsa.
               </p>
             </div>
             <div className="flex gap-2">
               <button
-                className="rounded-lg border border-white/80 bg-white text-emerald-700 text-xs px-3 py-1.5 hover:bg-neutral-100"
+                className="h-8 px-3 rounded-full bg-white text-[#2f4131] hover:bg-white/90 font-medium"
                 onClick={resetAll}
               >
                 Restablecer
               </button>
-              <button onClick={onClose} className="text-sm underline">
+              <button onClick={onClose} className="text-white/95 underline underline-offset-2 hover:text-white">
                 Cerrar
               </button>
             </div>
@@ -219,9 +219,9 @@ export default function BowlBuilderModal({ open, onClose }) {
         </div>
 
         {/* Body scrollable */}
-        <div className="p-5 space-y-6 overflow-y-auto">
+        <div className="p-5 space-y-4 sm:space-y-5 overflow-y-auto">
           {/* Resumen */}
-          <div className="rounded-xl border bg-neutral-50 p-3 text-xs text-neutral-700">
+          <div className="rounded-xl bg-white ring-1 ring-neutral-200 text-neutral-800 px-3 py-2 text-xs">
             Base: {base} · Prot: {protein} {isPremium && "(+ $4.000)"} · Top:{" "}
             {tops.length}/{MAX_TOPS} · Extras: {exts.length}/{MAX_EXTS} · Salsa:{" "}
             {sauce}
@@ -229,8 +229,8 @@ export default function BowlBuilderModal({ open, onClose }) {
 
           {/* Base */}
           <section>
-            <p className="text-sm font-semibold mb-2">1) Base</p>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            <p className="text-sm font-semibold text-[#2f4131] mb-2">1) Base</p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
               {bases.map((b) => (
                 <Tile key={b} active={b === base} onClick={() => setBase(b)}>
                   {ico(b)}&nbsp;{b}
@@ -241,8 +241,8 @@ export default function BowlBuilderModal({ open, onClose }) {
 
           {/* Proteína */}
           <section>
-            <p className="text-sm font-semibold mb-2">2) Proteína</p>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            <p className="text-sm font-semibold text-[#2f4131] mb-2">2) Proteína</p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
               {proteins.map((p) => (
                 <Tile
                   key={p.name}
@@ -259,12 +259,12 @@ export default function BowlBuilderModal({ open, onClose }) {
           {/* Toppings */}
           <section>
             <div className="flex items-center justify-between mb-2">
-              <p className="text-sm font-semibold">3) Toppings</p>
-              <p className="text-xs text-neutral-500">
+              <p className="text-sm font-semibold text-[#2f4131]">3) Toppings</p>
+              <p className="text-xs text-neutral-600">
                 Seleccionados: {tops.length}/{MAX_TOPS}
               </p>
             </div>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
               {toppings.map((t) => (
                 <Tile
                   key={t}
@@ -281,12 +281,12 @@ export default function BowlBuilderModal({ open, onClose }) {
           {/* Extras */}
           <section>
             <div className="flex items-center justify-between mb-2">
-              <p className="text-sm font-semibold">4) Extras</p>
-              <p className="text-xs text-neutral-500">
+              <p className="text-sm font-semibold text-[#2f4131]">4) Extras</p>
+              <p className="text-xs text-neutral-600">
                 Seleccionados: {exts.length}/{MAX_EXTS}
               </p>
             </div>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
               {extras.map((e) => (
                 <Tile
                   key={e}
@@ -302,8 +302,8 @@ export default function BowlBuilderModal({ open, onClose }) {
 
           {/* Salsa */}
           <section>
-            <p className="text-sm font-semibold mb-2">5) Salsa</p>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            <p className="text-sm font-semibold text-[#2f4131] mb-2">5) Salsa</p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
               {sauces.map((s) => (
                 <Tile key={s} active={s === sauce} onClick={() => setSauce(s)}>
                   {ico(s)}&nbsp;{s}
@@ -313,7 +313,7 @@ export default function BowlBuilderModal({ open, onClose }) {
           </section>
 
           {/* Total + Nota + Añadir */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 items-end">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 items-end">
             <div className="sm:col-span-2">
               <label className="block text-[11px] text-neutral-500">
                 Nota para cocina (opcional)

--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -46,16 +46,13 @@ export default function BowlsSection() {
   return (
     <div className="space-y-4">
       {/* CTA gigante (como otro “producto”) */}
-      <button
-        onClick={() => setOpen(true)}
-        className="relative w-full text-left rounded-2xl overflow-hidden shadow-card border border-alto-greige focus:outline-none focus:ring-2 focus:ring-emerald-600"
-      >
-        <div className="relative bg-gradient-to-br from-alto-primary via-emerald-600 to-green-700 p-5">
+      <button onClick={() => setOpen(true)} className="relative w-full text-left">
+        <div className="relative rounded-2xl p-3 sm:p-4 bg-gradient-to-r from-[#2f4131] to-[#355242] ring-1 ring-black/10 text-white">
           {/* 🍣 encima de la placa, debajo del chip */}
-          <div className="poke-decor-over">🍣</div>
+          <div className="poke-decor-over opacity-80 saturate-0">🍣</div>
 
           {/* Placa clara para contraste del texto */}
-          <div className="relative z-10 inline-block rounded-xl bg-white/90 backdrop-blur px-4 py-3 text-emerald-900 pr-28">
+          <div className="relative z-10 inline-block rounded-xl bg-white/10 backdrop-blur px-4 py-3 ring-1 ring-white/20 pr-28">
             <p className="text-[11px]">Personaliza a tu gusto</p>
             <h3 className="text-lg sm:text-xl font-extrabold tracking-tight">
               Armar bowl personalizado
@@ -65,11 +62,9 @@ export default function BowlsSection() {
             </p>
           </div>
 
-          {/* Chip “Desde” abajo a la derecha, encima de todo */}
-          <div className="absolute bottom-3 right-3 z-30">
-            <div className="chip-square chip-solid">
-              Desde&nbsp;<span className="font-bold">${COP(BASE_PRICE)}</span>
-            </div>
+          {/* Chip “Desde” arriba a la derecha, encima de todo */}
+          <div className="absolute right-4 top-4 z-30 rounded-full bg-white text-[#2f4131] font-semibold px-3 h-8 grid place-items-center shadow">
+            Desde&nbsp;<span className="font-bold">${COP(BASE_PRICE)}</span>
           </div>
         </div>
       </button>

--- a/src/styles.css
+++ b/src/styles.css
@@ -70,8 +70,8 @@ summary::-webkit-details-marker {
   right: -10px;
   bottom: 10px;
   font-size: 80px;
-  opacity: 0.75;
-  filter: drop-shadow(0 10px 14px rgba(0, 0, 0, 0.25));
+  opacity: 0.8;
+  filter: drop-shadow(0 10px 14px rgba(0, 0, 0, 0.25)) saturate(0);
   animation: poke-float 6s ease-in-out infinite;
   pointer-events: none;
   user-select: none;


### PR DESCRIPTION
## Summary
- align "Armar bowl" banner with brand gradient and pill
- apply brand colors and spacing to bowl builder modal options
- tone down decorative poke image

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a795c34fc8832786250c913af2526b