### PR TITLE
Refine bowl builder UI and table chip

### DIFF
--- a/src/components/BowlBuilderModal.jsx
+++ b/src/components/BowlBuilderModal.jsx
@@ -1,5 +1,4 @@
 import { useState, useMemo } from "react";
-import { AddButton } from "./Buttons";
 import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 
@@ -12,7 +11,7 @@ function Tile({ active, disabled, onClick, children }) {
       disabled={disabled && !active}
       aria-pressed={active}
       className={
-        "w-full text-left rounded-2xl px-4 py-3 text-sm transition ring-1 " +
+        "w-full text-left rounded-xl px-3 py-2 text-sm transition ring-1 " +
         (active
           ? "bg-[#2f4131] text-white ring-[#2f4131] shadow-sm"
           : "bg-white text-neutral-900 ring-neutral-200 hover:ring-neutral-300") +
@@ -196,22 +195,22 @@ export default function BowlBuilderModal({ open, onClose }) {
       {/* Contenedor con scroll interno */}
       <div className="relative w-full max-w-2xl max-h-[90vh] rounded-3xl overflow-hidden bg-[#FAF7F2] shadow-2xl flex flex-col">
         {/* Header */}
-        <div className="rounded-t-2xl bg-[#2f4131] text-white p-5">
+        <div className="rounded-t-2xl bg-[#2f4131] text-white p-4">
           <div className="flex items-start justify-between gap-3">
             <div>
-              <h3 className="text-white font-semibold text-lg">Arma tu bowl</h3>
-              <p className="text-white/90 text-sm">
+              <h3 className="text-base font-semibold">Arma tu bowl</h3>
+              <p className="text-white/90 text-xs">
                 1 base, 1 proteína, 4 toppings, 3 extras y 1 salsa.
               </p>
             </div>
             <div className="flex gap-2">
               <button
-                className="h-8 px-3 rounded-full bg-white text-[#2f4131] hover:bg-white/90 font-medium"
+                className="h-8 px-3 rounded-full bg-white text-[#2f4131] hover:bg-white/90 text-sm"
                 onClick={resetAll}
               >
                 Restablecer
               </button>
-              <button onClick={onClose} className="text-white/95 underline underline-offset-2 hover:text-white">
+              <button onClick={onClose} className="text-white/95 underline underline-offset-2 text-sm">
                 Cerrar
               </button>
             </div>
@@ -219,18 +218,18 @@ export default function BowlBuilderModal({ open, onClose }) {
         </div>
 
         {/* Body scrollable */}
-        <div className="p-5 space-y-4 sm:space-y-5 overflow-y-auto">
+        <div className="space-y-3 sm:space-y-4 px-4 pb-4 overflow-y-auto">
           {/* Resumen */}
-          <div className="rounded-xl bg-white ring-1 ring-neutral-200 text-neutral-800 px-3 py-2 text-xs">
+          <div className="rounded-lg bg-white ring-1 ring-neutral-200 text-neutral-800 px-3 py-2 text-sm">
             Base: {base} · Prot: {protein} {isPremium && "(+ $4.000)"} · Top:{" "}
             {tops.length}/{MAX_TOPS} · Extras: {exts.length}/{MAX_EXTS} · Salsa:{" "}
-            {sauce}
+            {sauce} · Total: ${COP(price)}
           </div>
 
           {/* Base */}
           <section>
-            <p className="text-sm font-semibold text-[#2f4131] mb-2">1) Base</p>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
+            <p className="text-[#2f4131] font-semibold text-sm mb-2">1) Base</p>
+            <div className="grid grid-cols-2 gap-2 sm:gap-3">
               {bases.map((b) => (
                 <Tile key={b} active={b === base} onClick={() => setBase(b)}>
                   {ico(b)}&nbsp;{b}
@@ -241,8 +240,8 @@ export default function BowlBuilderModal({ open, onClose }) {
 
           {/* Proteína */}
           <section>
-            <p className="text-sm font-semibold text-[#2f4131] mb-2">2) Proteína</p>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
+            <p className="text-[#2f4131] font-semibold text-sm mb-2">2) Proteína</p>
+            <div className="grid grid-cols-2 gap-2 sm:gap-3">
               {proteins.map((p) => (
                 <Tile
                   key={p.name}
@@ -259,12 +258,12 @@ export default function BowlBuilderModal({ open, onClose }) {
           {/* Toppings */}
           <section>
             <div className="flex items-center justify-between mb-2">
-              <p className="text-sm font-semibold text-[#2f4131]">3) Toppings</p>
+              <p className="text-[#2f4131] font-semibold text-sm">3) Toppings</p>
               <p className="text-xs text-neutral-600">
                 Seleccionados: {tops.length}/{MAX_TOPS}
               </p>
             </div>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
+            <div className="grid grid-cols-2 gap-2 sm:gap-3">
               {toppings.map((t) => (
                 <Tile
                   key={t}
@@ -281,12 +280,12 @@ export default function BowlBuilderModal({ open, onClose }) {
           {/* Extras */}
           <section>
             <div className="flex items-center justify-between mb-2">
-              <p className="text-sm font-semibold text-[#2f4131]">4) Extras</p>
+              <p className="text-[#2f4131] font-semibold text-sm">4) Extras</p>
               <p className="text-xs text-neutral-600">
                 Seleccionados: {exts.length}/{MAX_EXTS}
               </p>
             </div>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
+            <div className="grid grid-cols-2 gap-2 sm:gap-3">
               {extras.map((e) => (
                 <Tile
                   key={e}
@@ -302,8 +301,8 @@ export default function BowlBuilderModal({ open, onClose }) {
 
           {/* Salsa */}
           <section>
-            <p className="text-sm font-semibold text-[#2f4131] mb-2">5) Salsa</p>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
+            <p className="text-[#2f4131] font-semibold text-sm mb-2">5) Salsa</p>
+            <div className="grid grid-cols-2 gap-2 sm:gap-3">
               {sauces.map((s) => (
                 <Tile key={s} active={s === sauce} onClick={() => setSauce(s)}>
                   {ico(s)}&nbsp;{s}
@@ -312,27 +311,32 @@ export default function BowlBuilderModal({ open, onClose }) {
             </div>
           </section>
 
-          {/* Total + Nota + Añadir */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 items-end">
-            <div className="sm:col-span-2">
-              <label className="block text-[11px] text-neutral-500">
-                Nota para cocina (opcional)
-              </label>
-              <input
-                value={note}
-                onChange={(e) => setNote(e.target.value)}
-                placeholder="Ej.: sin sal, extra salsa, poco picante..."
-                maxLength={120}
-                className="mt-1 w-full rounded-lg border px-2 py-2 text-sm"
-              />
-            </div>
-            <div className="rounded-xl border bg-neutral-50 p-3">
-              <p className="text-xs text-neutral-600">Total</p>
-              <p className="text-xl font-bold">${COP(price)}</p>
-              <AddButton className="mt-2" onClick={addToCart}>
-                Añadir al carrito
-              </AddButton>
-            </div>
+          {/* Nota y acciones */}
+          <div>
+            <label className="block text-xs text-neutral-600">
+              Nota para cocina (opcional)
+            </label>
+            <input
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Ej.: sin sal, extra salsa, poco picante..."
+              maxLength={120}
+              className="mt-1 w-full rounded-lg border px-2 py-2 text-sm"
+            />
+          </div>
+          <div className="flex gap-2 pt-2">
+            <button
+              onClick={onClose}
+              className="flex-1 h-9 rounded-lg bg-white/10 text-white hover:bg-white/15 ring-1 ring-white/15 text-sm"
+            >
+              Seguir pidiendo
+            </button>
+            <button
+              onClick={addToCart}
+              className="flex-1 h-9 rounded-lg bg-[#2f4131] text-white hover:bg-[#243326] text-sm"
+            >
+              Añadir al carrito
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -32,6 +32,8 @@ export default function BowlsSection() {
   const { addItem } = useCart();
   const [open, setOpen] = useState(false);
 
+  const openBuilder = () => setOpen(true);
+
   const addPre = () =>
     addItem({
       productId: PREBOWL.id,
@@ -46,28 +48,33 @@ export default function BowlsSection() {
   return (
     <div className="space-y-4">
       {/* CTA gigante (como otro “producto”) */}
-      <button onClick={() => setOpen(true)} className="relative w-full text-left">
-        <div className="relative rounded-2xl p-3 sm:p-4 bg-gradient-to-r from-[#2f4131] to-[#355242] ring-1 ring-black/10 text-white">
-          {/* 🍣 encima de la placa, debajo del chip */}
-          <div className="poke-decor-over opacity-80 saturate-0">🍣</div>
-
-          {/* Placa clara para contraste del texto */}
-          <div className="relative z-10 inline-block rounded-xl bg-white/10 backdrop-blur px-4 py-3 ring-1 ring-white/20 pr-28">
-            <p className="text-[11px]">Personaliza a tu gusto</p>
-            <h3 className="text-lg sm:text-xl font-extrabold tracking-tight">
+      <div
+        onClick={openBuilder}
+        role="button"
+        aria-label="Armar bowl"
+        className="relative rounded-2xl overflow-hidden ring-1 ring-black/10 bg-gradient-to-r from-[#2f4131] to-[#355242]"
+      >
+        {/* Imagen decorativa */}
+        <div className="absolute inset-y-0 right-0 w-40 opacity-70 pointer-events-none flex items-center justify-center">
+          🍣
+        </div>
+        <div className="absolute inset-0 p-4 sm:p-5 pr-28 pb-16 flex flex-col justify-between">
+          <div>
+            <p className="text-white/85 text-xs font-medium">Personaliza a tu gusto</p>
+            <h3 className="text-white font-semibold text-xl sm:text-2xl">
               Armar bowl personalizado
             </h3>
-            <p className="text-xs">
+            <p className="text-white/90 text-sm">
               1 base, 1 proteína, 4 toppings, 3 extras y 1 salsa
             </p>
           </div>
-
-          {/* Chip “Desde” arriba a la derecha, encima de todo */}
-          <div className="absolute right-4 top-4 z-30 rounded-full bg-white text-[#2f4131] font-semibold px-3 h-8 grid place-items-center shadow">
-            Desde&nbsp;<span className="font-bold">${COP(BASE_PRICE)}</span>
+          <div className="mt-3 flex items-center justify-between">
+            <div className="absolute right-4 bottom-4 z-10 rounded-full bg-white text-[#2f4131] font-semibold px-3 h-9 grid place-items-center shadow">
+              Desde&nbsp;<span className="font-bold">${COP(BASE_PRICE)}</span>
+            </div>
           </div>
         </div>
-      </button>
+      </div>
 
       {/* Card del prearmado */}
       <div className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -27,9 +27,11 @@ export default function Header() {
 
             {/* ✅ Chip con la mesa (si existe en la URL o guardada) */}
             {table && (
-              <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-emerald-100 text-emerald-800 px-3 py-1 text-xs font-semibold">
-                Mesa {table}
-              </span>
+              <div className="mt-2 flex justify-center">
+                <span className="inline-flex items-center gap-1 h-7 px-3 rounded-full text-xs border border-neutral-300 bg-white text-neutral-800">
+                  Mesa {table}
+                </span>
+              </div>
             )}
             <div className="my-2 h-px bg-black/10 w-full" />
           </div>


### PR DESCRIPTION
## Summary
- Center table chip and apply compact styling
- Rework bowl CTA banner into full clickable card
- Shrink and tidy bowl builder modal for a compact experience

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a79815970c8327a28281b311ec6855