### PR TITLE
Add fixed height to bowl builder banner

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -52,7 +52,7 @@ export default function BowlsSection() {
         onClick={openBuilder}
         role="button"
         aria-label="Armar bowl"
-        className="relative rounded-2xl overflow-hidden ring-1 ring-black/10 bg-gradient-to-r from-[#2f4131] to-[#355242]"
+        className="relative h-40 rounded-2xl overflow-hidden ring-1 ring-black/10 bg-gradient-to-r from-[#2f4131] to-[#355242]"
       >
         {/* Imagen decorativa */}
         <div className="absolute inset-y-0 right-0 w-40 opacity-70 pointer-events-none flex items-center justify-center">


### PR DESCRIPTION
## Summary
- prevent CTA wrapper collapse by adding `h-40` height class so absolute content fills container

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a79d38b4b88327b48749c205fd149d