### PR TITLE
fix: restore sticky category bar

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -1,12 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 
 const slugify = (s) =>
-  s
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
+  s.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "")
+   .replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
 
 export default function CategoryBar({ onOpenGuide }) {
   const [sections, setSections] = useState([]);
@@ -14,7 +10,6 @@ export default function CategoryBar({ onOpenGuide }) {
   const barRef = useRef(null);
   const ioRef = useRef(null);
 
-  // Leer secciones del DOM cuando monta
   useEffect(() => {
     const nodes = document.querySelectorAll("[data-aa-section]");
     const list = Array.from(nodes).map((n) => {
@@ -25,23 +20,18 @@ export default function CategoryBar({ onOpenGuide }) {
     setSections(list);
   }, []);
 
-  // Observer con rootMargin basado en la altura real de la barra
   useEffect(() => {
     if (!sections.length) return;
-    const barH = barRef.current?.offsetHeight || 48;
+    const barH = barRef.current?.offsetHeight || 44;
     const marginTop = -(barH + 8);
     const marginBottom = -Math.round(window.innerHeight * 0.45);
 
     ioRef.current?.disconnect();
     const io = new IntersectionObserver(
       (entries) => {
-        for (const e of entries) {
-          if (e.isIntersecting) {
-            setActive(e.target.id);
-          }
-        }
+        for (const e of entries) if (e.isIntersecting) setActive(e.target.id);
       },
-      { root: null, rootMargin: `${marginTop}px 0px ${marginBottom}px 0px`, threshold: [0.2, 0.4, 0.6] }
+      { root: null, rootMargin: `${marginTop}px 0px ${marginBottom}px 0px`, threshold: [0.2, 0.5] }
     );
     sections.forEach(({ el }) => io.observe(el));
     ioRef.current = io;
@@ -51,21 +41,22 @@ export default function CategoryBar({ onOpenGuide }) {
   const scrollTo = (id) => {
     const el = document.getElementById(id);
     if (!el) return;
-    const barH = barRef.current?.offsetHeight || 48;
-    const y = el.getBoundingClientRect().top + window.scrollY - barH - 8;
-    setActive(id); // fallback visual inmediato
-    window.scrollTo({ top: y, behavior: "smooth" });
+    const barH = barRef.current?.offsetHeight || 44;
+    window.scrollTo({ top: el.getBoundingClientRect().top + window.scrollY - barH - 8, behavior: "smooth" });
+    setActive(id);
   };
 
   return (
+    // STICKY en el WRAPPER EXTERNO (no meter overflow aquí)
     <div
       ref={barRef}
-      className="sticky z-50 bg-[rgba(250,247,242,0.92)] backdrop-blur border-b border-black/5"
+      className="sticky z-[60] bg-[rgba(250,247,242,0.92)] backdrop-blur border-b border-black/5"
       style={{ top: "env(safe-area-inset-top, 0px)" }}
       aria-label="Categorías del menú"
     >
+      {/* full-bleed */}
       <div className="w-full px-3 sm:px-4 py-2 flex items-center gap-2">
-        {/* Carril scrolleable de categorías */}
+        {/* carril scrolleable */}
         <div className="flex-1 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <div className="flex gap-2 w-max">
             {sections.map(({ id, label }) => (
@@ -77,7 +68,7 @@ export default function CategoryBar({ onOpenGuide }) {
                   "px-3 py-1 rounded-full text-sm border transition whitespace-nowrap",
                   active === id
                     ? "bg-[#2f4131] text-white border-[#2f4131] shadow"
-                    : "bg-white text-neutral-800 border-neutral-300 hover:border-neutral-400",
+                    : "bg-white text-neutral-800 border-neutral-300 hover:border-neutral-400"
                 ].join(" ")}
               >
                 {label}
@@ -86,12 +77,13 @@ export default function CategoryBar({ onOpenGuide }) {
           </div>
         </div>
 
-        {/* Botón Alérgenos fijo a la derecha */}
+        {/* botón Guía / Alérgenos (tamaño XS/SM) */}
         <button
           type="button"
           onClick={onOpenGuide}
-          className="shrink-0 h-8 px-2.5 rounded-full text-xs border border-[#2f4131]/30 text-[#2f4131] bg-white/50 hover:bg-[#2f4131] hover:text-white hover:border-[#2f4131] shadow-sm ring-1 ring-black/5 transition focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
-          aria-label="Guía dietaria y alérgenos"
+          className="shrink-0 h-7 px-2.5 sm:h-8 sm:px-3 text-xs sm:text-sm rounded-full border border-[#2f4131]/30 text-[#2f4131] bg-white/50
+                     hover:bg-[#2f4131] hover:text-white hover:border-[#2f4131]
+                     shadow-sm ring-1 ring-black/5 transition focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
         >
           Alérgenos
         </button>
@@ -99,4 +91,3 @@ export default function CategoryBar({ onOpenGuide }) {
     </div>
   );
 }
-

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -11,8 +11,8 @@ export default function Header() {
 
   return (
     <>
-      <div className="max-w-3xl mx-auto px-5 sm:px-6 md:px-8 pt-3 pb-2 sm:pt-4 sm:pb-3">
-        <header>
+      <header className="bg-[#F3EDE4] overflow-visible">
+        <div className="max-w-3xl mx-auto px-5 sm:px-6 md:px-8 pt-3 pb-2 sm:pt-4 sm:pb-3">
           {/* Logo centrado y sin fondo */}
           <div className="pt-3 sm:pt-4">
             <img
@@ -21,7 +21,6 @@ export default function Header() {
               className="mx-auto h-28 sm:h-32 md:h-36 w-auto object-contain drop-shadow-sm"
             />
             <p className="mt-2 mb-2 text-sm sm:text-[15px] text-neutral-600">
-
               Ingredientes locales y de temporada · Pet Friendly
             </p>
 
@@ -35,13 +34,9 @@ export default function Header() {
             )}
             <div className="my-2 h-px bg-black/10 w-full" />
           </div>
-        </header>
-      </div>
-
-      <div className="mb-1">
+        </div>
         <CategoryBar onOpenGuide={() => setOpenGuide(true)} />
-      </div>
-
+      </header>
 
       <GuideModal open={openGuide} onClose={() => setOpenGuide(false)}>
         <DietaryGuide />


### PR DESCRIPTION
## Summary
- replace CategoryBar with full-bleed sticky implementation
- move CategoryBar outside constrained container in Header so ancestors don't break sticky

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a7a5083acc832785da942b457435f8