### PR TITLE
feat: add responsive pill sizes for bowls CTA and category bar

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
-import { AddIconButton, StatusChip } from "./Buttons";
+import { AddIconButton, StatusChip, PILL_XS, PILL_SM } from "./Buttons";
 import BowlBuilderModal from "./BowlBuilderModal";
 import stock from "../data/stock.json";
 
@@ -56,14 +56,14 @@ export default function BowlsSection() {
     <div className="space-y-4">
       {/* CTA gigante (como otro “producto”) */}
       <div className="-mx-4 sm:-mx-6 px-4 sm:px-6">
-        <div className="relative overflow-hidden rounded-2xl ring-1 ring-black/10 bg-gradient-to-r from-[#2f4131] to-[#355242]">
+        <div className="relative overflow-hidden rounded-2xl ring-1 ring-black/10 bg-gradient-to-r from-[#2f4131] to-[#355242] h-36 sm:h-44 md:h-56">
           <img
             src="/poke1.png"
             alt=""
             aria-hidden
-            className="absolute bottom-2 right-24 w-40 sm:w-56 opacity-90 drop-shadow-xl pointer-events-none animate-[spin_40s_linear_infinite] z-10"
+            className="absolute bottom-[-6px] right-0 sm:right-2 w-44 sm:w-60 md:w-72 object-contain drop-shadow-xl pointer-events-none animate-[spin_40s_linear_infinite] z-10"
           />
-          <div className="absolute inset-0 p-4 sm:p-5 pr-28 pb-16 flex flex-col justify-between">
+          <div className="absolute inset-0 p-4 sm:p-5 pr-40 sm:pr-48 flex flex-col justify-between">
             <div>
               <p className="text-white/85 text-xs font-medium">Personaliza a tu gusto</p>
               <h3 className="text-white font-semibold text-xl sm:text-2xl">
@@ -74,17 +74,27 @@ export default function BowlsSection() {
               </p>
             </div>
           </div>
-          <div className="absolute top-4 right-4 z-10 h-9 px-3 rounded-full bg-white text-[#2f4131] font-semibold grid place-items-center shadow whitespace-nowrap">
+          <div
+            className={[
+              "absolute top-3 right-3 z-20 rounded-full bg-white text-[#2f4131] font-semibold",
+              "grid place-items-center shadow-sm whitespace-nowrap",
+              PILL_XS, "sm:" + PILL_SM,
+            ].join(" ")}
+          >
             Desde {formatCOP(BASE_PRICE)}
           </div>
           <button
             onClick={openBuilder}
             aria-label="Armar bowl personalizado"
-            className="absolute bottom-4 right-4 z-20 h-10 px-4 rounded-full bg-white text-[#2f4131] font-semibold shadow hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+            className={[
+              "absolute bottom-3 right-3 z-30 rounded-full bg-white text-[#2f4131] font-semibold",
+              "shadow-sm hover:bg-white/90 focus:outline-none",
+              "focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]",
+              PILL_XS, "sm:" + PILL_SM,
+            ].join(" ")}
           >
             Armar
           </button>
-          <div className="h-28 sm:h-36"></div>
         </div>
       </div>
 

--- a/src/components/Buttons.jsx
+++ b/src/components/Buttons.jsx
@@ -113,4 +113,8 @@ export function StatusChip({ variant = "neutral", className = "", children }) {
   );
 }
 
+// Tamaños reutilizables para pills
+export const PILL_XS = "h-7 px-2.5 text-xs";
+export const PILL_SM = "h-8 px-3 text-sm";
+
 export default AddButton;

--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { PILL_XS, PILL_SM } from "./Buttons";
 
 const slugify = (s) =>
   s
@@ -90,7 +91,13 @@ export default function CategoryBar({ onOpenGuide }) {
         <button
           type="button"
           onClick={onOpenGuide}
-          className="shrink-0 h-8 px-2.5 rounded-full text-xs border border-[#2f4131]/30 text-[#2f4131] bg-white/50 hover:bg-[#2f4131] hover:text-white hover:border-[#2f4131] shadow-sm ring-1 ring-black/5 transition focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+          className={[
+            "shrink-0 rounded-full border border-[#2f4131]/30 text-[#2f4131] bg-white/50",
+            "hover:bg-[#2f4131] hover:text-white hover:border-[#2f4131]",
+            "shadow-sm ring-1 ring-black/5 transition focus:outline-none",
+            "focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]",
+            PILL_XS, "sm:" + PILL_SM
+          ].join(" ")}
           aria-label="Guía dietaria y alérgenos"
         >
           Alérgenos


### PR DESCRIPTION
## Summary
- add pill size utilities
- use pill utilities in CategoryBar and BowlsSection CTA
- restore poke bowl image slow spin animation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7a481c3948327ab6173ad0365100f