### PR TITLE
fix: guard browser APIs and unify currency formatting

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -1,7 +1,7 @@
 // src/components/BowlsSection.jsx
 import { useState } from "react";
 import { useCart } from "../context/CartContext";
-import { COP } from "../utils/money";
+import { COP, formatCOP } from "../utils/money";
 import { AddIconButton, StatusChip, PILL_XS, PILL_SM } from "./Buttons";
 import BowlBuilderModal from "./BowlBuilderModal";
 import stock from "../data/stock.json";
@@ -13,12 +13,6 @@ function stateFor(productId) {
 
 const BASE_PRICE = Number(import.meta.env.VITE_BOWL_BASE_PRICE || 32000);
 
-const formatCOP = (n) =>
-  n.toLocaleString("es-CO", {
-    style: "currency",
-    currency: "COP",
-    maximumFractionDigits: 0,
-  });
 
 // Poke Hawaiano (único prearmado)
 const PREBOWL = {

--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { useCart } from "../context/CartContext";
 import SwipeRevealItem from "./SwipeRevealItem";
+import { formatCOP } from "../utils/money";
 
 const SHEET_BG = "#1f2621"; // fondo del sheet
 
@@ -8,20 +9,19 @@ const safeNum = (raw) => {
   const n = String(raw || "").replace(/\D/g, "");
   return n.startsWith("57") ? n : (n ? `57${n}` : "");
 };
-const formatCOP = (v) => {
-  const n = Number(String(v).replace(/[^\d.-]/g, ""));
-  if (!isFinite(n)) return String(v);
-  return n.toLocaleString("es-CO", { style: "currency", currency: "COP", maximumFractionDigits: 0 });
-};
+
 const getTable = () => {
   try {
-    for (const k of ["aa_table","aa_table_num","aa_t","mesa","table"]) {
-      const v = localStorage.getItem(k);
+    if (typeof window === "undefined") return "";
+    for (const k of ["aa_table", "aa_table_num", "aa_t", "mesa", "table"]) {
+      const v = window.localStorage?.getItem?.(k);
       if (v) return v;
     }
-    const sp = new URL(location.href).searchParams.get("t");
+    const sp = new URL(window.location.href).searchParams.get("t");
     return sp || "";
-  } catch { return ""; }
+  } catch {
+    return "";
+  }
 };
 const buildWaText = ({ items = [], total = 0, note = "" }) => {
   const mesa = getTable();
@@ -189,7 +189,7 @@ export default function CartDrawer({ open, onClose }) {
           <div className="flex items-center justify-between text-white">
             <span className="text-sm">Total</span>
             <span className="font-semibold text-lg">
-              {total?.toLocaleString?.("es-CO", { style: "currency", currency: "COP" }) || total}
+              {formatCOP(total)}
             </span>
           </div>
           <div className="mt-3 grid grid-cols-2 gap-2">

--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -23,6 +23,7 @@ export default function CategoryBar({ onOpenGuide }) {
 
   useEffect(() => {
     if (!sections.length) return;
+    if (typeof window === "undefined") return;
     const barH = barRef.current?.offsetHeight || 44;
     const marginTop = -(barH + 8);
     const marginBottom = -Math.round(window.innerHeight * 0.45);
@@ -41,9 +42,12 @@ export default function CategoryBar({ onOpenGuide }) {
 
   const scrollTo = (id) => {
     const el = document.getElementById(id);
-    if (!el) return;
+    if (!el || typeof window === "undefined") return;
     const barH = barRef.current?.offsetHeight || 44;
-    window.scrollTo({ top: el.getBoundingClientRect().top + window.scrollY - barH - 8, behavior: "smooth" });
+    window.scrollTo({
+      top: el.getBoundingClientRect().top + window.scrollY - barH - 8,
+      behavior: "smooth",
+    });
     setActive(id);
   };
 

--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -2,17 +2,7 @@ import React from "react";
 import Section from "./Section";
 import { useCart } from "../context/CartContext";
 import { AddIconButton } from "./Buttons";
-import { COP as COPUtil } from "../utils/money";
-
-// Formateo COP con guardado (si COPUtil no existe o falla)
-const money = (v) => {
-  try {
-    if (typeof COPUtil === "function") return COPUtil(v);
-  } catch {}
-  const n = Number(String(v).replace(/[^\d.-]/g, ""));
-  if (!isFinite(n)) return String(v);
-  return n.toLocaleString("es-CO", { maximumFractionDigits: 0 });
-};
+import { COP } from "../utils/money";
 
 // DATA EXACTA DE LA CARTA
 const SODAS = [
@@ -52,7 +42,7 @@ function Card({ item, onAdd }) {
 
       {/* Precio fijo arriba-derecha con ancho mínimo para no chocar */}
       <div className="absolute top-2 right-2 min-w-[64px] text-right text-neutral-900 font-semibold text-sm">
-        {"$" + money(item.price)}
+        {"$" + COP(item.price)}
       </div>
 
       {/* FAB compacto y claro de la zona de texto */}
@@ -64,7 +54,7 @@ function Card({ item, onAdd }) {
             productId: item.id,
             name: item.name,
             price: item.price,
-            priceFmt: "$" + money(item.price),
+            priceFmt: "$" + COP(item.price),
             qty: 1,
           })
         }

--- a/src/components/QrPoster.jsx
+++ b/src/components/QrPoster.jsx
@@ -11,13 +11,16 @@ export default function QrPoster({ url }) {
   // Si viene mesa, el QR apunta a url?t=XX; si no, a url “pelado”
   const qrTarget = table ? `${url}?t=${encodeURIComponent(table)}` : url;
 
-  const handlePrint = () => window.print();
+  const handlePrint = () => {
+    if (typeof window !== "undefined") window.print();
+  };
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(qrTarget);
-      alert("URL copiada al portapapeles");
+      await navigator?.clipboard?.writeText(qrTarget);
+      if (typeof window !== "undefined") window.alert("URL copiada al portapapeles");
     } catch {
-      alert("No se pudo copiar. Copia manualmente: " + qrTarget);
+      if (typeof window !== "undefined")
+        window.alert("No se pudo copiar. Copia manualmente: " + qrTarget);
     }
   };
 

--- a/src/utils/money.js
+++ b/src/utils/money.js
@@ -1,1 +1,15 @@
-export const COP = (n) => n.toLocaleString("es-CO");
+export const COP = (n) => {
+  const num = Number(String(n).replace(/[^\d.-]/g, ""));
+  if (!isFinite(num)) return "0";
+  return num.toLocaleString("es-CO", { maximumFractionDigits: 0 });
+};
+
+export const formatCOP = (v) => {
+  const num = Number(String(v).replace(/[^\d.-]/g, ""));
+  if (!isFinite(num)) return String(v);
+  return num.toLocaleString("es-CO", {
+    style: "currency",
+    currency: "COP",
+    maximumFractionDigits: 0,
+  });
+};

--- a/src/utils/table.js
+++ b/src/utils/table.js
@@ -1,13 +1,14 @@
 // src/utils/table.js
 export function getTableId() {
   try {
+    if (typeof window === "undefined") return "";
     const params = new URLSearchParams(window.location.search);
     const t = params.get("t");
     if (t) {
-      localStorage.setItem("aa_table", t);
+      window.localStorage?.setItem("aa_table", t);
       return t;
     }
-    return localStorage.getItem("aa_table") || "";
+    return window.localStorage?.getItem("aa_table") || "";
   } catch {
     return "";
   }


### PR DESCRIPTION
## Summary
- add robust COP formatting utility and reuse across sections
- guard browser-only APIs like window and localStorage
- clean up drink cards and cart drawer currency handling

## Testing
- `npm run build`
- `npm run dev` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d9269a48832780adf81287264262