### PR TITLE
docs: annotate product data for easier edits

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -11,10 +11,12 @@ function stateFor(productId) {
   return s === "low" ? "low" : s === false ? "out" : "ok";
 }
 
+// ← editar nombres y precios aquí
 const BASE_PRICE = Number(import.meta.env.VITE_BOWL_BASE_PRICE || 32000);
 
 
 // Poke Hawaiano (único prearmado)
+// ← editar nombres y precios aquí
 const PREBOWL = {
   id: "bowl-poke-hawaiano",
   name: "Poke Hawaiano",
@@ -51,6 +53,7 @@ export default function BowlsSection() {
       {/* CTA gigante (como otro “producto”) */}
       <div className="-mx-4 sm:-mx-6 px-4 sm:px-6">
         <div className="relative overflow-hidden rounded-2xl ring-1 ring-black/10 bg-gradient-to-r from-[#2f4131] to-[#355242] h-36 sm:h-44 md:h-56">
+          {/* ← editar clases y ruta de la imagen aquí */}
           <img
             src="/poke1.png"
             alt=""

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -7,6 +7,7 @@ import stock from "../data/stock.json";
 // ————————————————————————————————————————
 // Configuración de bebidas
 // milkPolicy: 'none' | 'optional' | 'required'
+// ← editar nombres y precios aquí
 const MILK_OPTIONS = [
   { id: "entera", label: "Entera", delta: 0 },
   { id: "deslactosada", label: "Deslactosada", delta: 0 },
@@ -14,6 +15,7 @@ const MILK_OPTIONS = [
 ];
 
 // Cafés (agrupados)
+// ← editar nombres y precios aquí
 const COFFEES = [
   // Sin leche por defecto
   {
@@ -85,6 +87,7 @@ const COFFEES = [
 ];
 
 // Infusiones y tés (incluye Chai)
+// ← editar nombres y precios aquí
 const INFUSIONS = [
   {
     id: "inf-aromatica",

--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -5,6 +5,7 @@ import { AddIconButton } from "./Buttons";
 import { COP } from "../utils/money";
 
 // DATA EXACTA DE LA CARTA
+// ← editar nombres y precios aquí
 const SODAS = [
   { id: "soda-zen", name: "Soda Zen", price: 3500, desc: "Frutos rojos, Durazno, Limonata rosada" },
   { id: "coca-250", name: "Coca-Cola 250 mL", price: 2500 },
@@ -18,6 +19,7 @@ const SODAS = [
   { id: "hatsu-yerbabuena-botella", name: "Hatsu Yerbabuena (botella)", price: 4000 },
 ];
 
+// ← editar nombres y precios aquí
 const OTHERS = [
   { id: "te-hatsu-400", name: "Té Hatsu 400 mL", price: 5000, desc: "Rojo, Negro, Aguamarina, Rosado, Fucsia, Blanco, Amarillo, Verde" },
   { id: "te-hatsu-caja-200", name: "Té Hatsu Caja 200 mL", price: 2000, desc: "Blanco, Amarillo, Aguamarina" },

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -10,6 +10,7 @@ function stateFor(productId) {
 }
 
 export function Breakfasts() {
+  // ← editar nombres y precios aquí
   const items = [
     {
       id: "des-sendero",
@@ -46,6 +47,7 @@ export function Breakfasts() {
 }
 
 export function Mains() {
+  // ← editar nombres y precios aquí
   const items = [
     {
       id: "main-salmon",
@@ -92,12 +94,14 @@ export function Desserts() {
 
   // Sabores + precios específicos (según tu instrucción):
   // rojos y amarillos: $10.000 · chococumbre: $11.000 · blancos: $12.000
+  // ← editar nombres y precios aquí
   const cumbreSabores = [
     { id: "rojos", label: "Frutos rojos" },
     { id: "amarillos", label: "Frutos amarillos" },
     { id: "blancos", label: "Frutos blancos" },
     { id: "choco", label: "Chococumbre" },
   ];
+  // ← editar nombres y precios aquí
   const cumbrePrices = {
     rojos: 10000,
     amarillos: 10000,
@@ -107,6 +111,7 @@ export function Desserts() {
   const cumbreStock = stock.cumbre || {};
 
   // Postres de vitrina (precios según carta)
+  // ← editar nombres y precios aquí
   const base = [
     {
       id: "post-red",

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -14,12 +14,14 @@ export default function Sandwiches() {
   const cart = useCart();
   const [size, setSize] = useState("clasico"); // 'clasico' | 'grande'
 
+  // ← editar nombres y precios aquí
   const sizes = [
     { id: "clasico", label: "Clásico (100 g de proteína)" },
     { id: "grande", label: "Grande (300 g de proteína)" },
   ];
 
   // Precios por sándwich (unico = precio único)
+  // ← editar nombres y precios aquí
   const priceByItem = {
     cerdo: { clasico: 22000, grande: 35000 },
     pollo: { clasico: 22000, grande: 35000 },
@@ -28,6 +30,7 @@ export default function Sandwiches() {
     cosecha: { unico: 24000 },
   };
 
+  // ← editar nombres y precios aquí
   const items = [
     {
       key: "cerdo",

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -3,6 +3,7 @@ import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 import stock from "../data/stock.json";
 
+// ← editar nombres y precios aquí
 const smoothies = [
   {
     name: "Brisas Tropicales",
@@ -21,6 +22,7 @@ const smoothies = [
   },
 ];
 
+// ← editar nombres y precios aquí
 const funcionales = [
   {
     name: "Elixir del Cóndor (Detox)",

--- a/src/data/stock.json
+++ b/src/data/stock.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Valores de disponibilidad: true, false y \"low\"",
   "products": {
     "des-sendero": true,
     "des-cumbre": "low",


### PR DESCRIPTION
## Summary
- add edit hints to product arrays and configuration constants across components
- document availability values in `stock.json`
- note where to adjust bowl promo image classes and source

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7dd7d3a2c832785ee4f974196a38e