### PR TITLE
Mejoras de accesibilidad y cierre con Escape en modales

### DIFF
--- a/src/components/BowlBuilderModal.jsx
+++ b/src/components/BowlBuilderModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 
@@ -73,6 +73,12 @@ function ico(label) {
 }
 
 export default function BowlBuilderModal({ open, onClose }) {
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === "Escape") onClose?.(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   const cart = useCart();
   if (!open) return null;
 
@@ -180,17 +186,10 @@ export default function BowlBuilderModal({ open, onClose }) {
     onClose();
   };
 
-  const closeOnBg = (e) => {
-    if (e.target === e.currentTarget) onClose();
-  };
-
   return (
-    <div
-      className="fixed inset-0 z-[98]"
-      onClick={closeOnBg}
-    >
+    <div className="fixed inset-0 z-[98]">
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/60 z-[98]" />
+      <div className="absolute inset-0 bg-black/60 z-[98]" onClick={onClose} />
 
       {/* Contenedor con scroll interno */}
       <div className="absolute inset-x-0 bottom-0 z-[99] w-full max-w-2xl max-h-[90vh] mx-auto rounded-3xl overflow-hidden bg-[#FAF7F2] shadow-2xl flex flex-col">

--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -79,6 +79,12 @@ export default function CartDrawer({ open, onClose }) {
     return () => { document.body.style.overflow = prev; };
   }, [open]);
 
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === "Escape") onClose?.(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   if (!open) return null;
 
   return (

--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -69,6 +69,7 @@ export default function CategoryBar({ onOpenGuide }) {
                 key={id}
                 onClick={() => scrollTo(id)}
                 aria-pressed={active === id}
+                aria-current={active === id ? "true" : undefined}
                 className={[
                   "px-3 py-1 rounded-full text-sm border transition whitespace-nowrap",
                   active === id

--- a/src/components/FloatingCartBar.jsx
+++ b/src/components/FloatingCartBar.jsx
@@ -24,6 +24,9 @@ export default function FloatingCartBar({ items, total, onOpen, secondaryAction,
                   {secondaryLabel}
                 </button>
               )}
+              <span className="sr-only" aria-live="polite">
+                Total actualizado: {total?.toLocaleString?.("es-CO", { style: "currency", currency: "COP" })}
+              </span>
               <button
                 onClick={onOpen}
                 className="h-10 px-4 rounded-xl bg-[#2f4131] text-white hover:bg-[#243326] transition focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"

--- a/src/components/GuideModal.jsx
+++ b/src/components/GuideModal.jsx
@@ -3,10 +3,10 @@ import { createPortal } from "react-dom";
 
 export default function GuideModal({ open, onClose, children }) {
   useEffect(() => {
-    const onKey = (e) => e.key === "Escape" && onClose?.();
-    if (open) document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+    const onKey = (e) => { if (e.key === "Escape") onClose?.(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
 
   if (!open) return null;
   return createPortal(


### PR DESCRIPTION
## Summary
- Marcar categoría activa con `aria-current` en la barra de categorías
- Cerrar modales al presionar Escape y al hacer click en el backdrop
- Anunciar cambios en el total del carrito con `aria-live` oculto

## Testing
- `npm test` *(falla: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8d2c56fdc832788aabd0cffd9799f