### PR TITLE
Optimize loading with preconnect and lazy assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Alto Andino</title>
+    <link rel="preconnect" href="https://wa.me" crossorigin>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -1,9 +1,9 @@
 // src/components/BowlsSection.jsx
-import { useState } from "react";
+import React, { lazy, Suspense, useState } from "react";
 import { useCart } from "../context/CartContext";
 import { COP, formatCOP } from "../utils/money";
 import { AddIconButton, StatusChip, PILL_XS, PILL_SM } from "./Buttons";
-import BowlBuilderModal from "./BowlBuilderModal";
+const BowlBuilderModal = lazy(() => import("./BowlBuilderModal"));
 import { getStockState, slugify } from "../utils/stock";
 
 // ← editar nombres y precios aquí
@@ -53,6 +53,9 @@ export default function BowlsSection() {
             src="/poke1.png"
             alt=""
             aria-hidden
+            loading="lazy"
+            decoding="async"
+            fetchpriority="low"
             className="absolute bottom-[-6px] right-0 sm:right-2 w-44 sm:w-60 md:w-72 object-contain drop-shadow-xl pointer-events-none animate-[spin_40s_linear_infinite] z-10"
 
           />
@@ -115,7 +118,11 @@ export default function BowlsSection() {
       </div>
 
       {/* Modal de armado */}
-      <BowlBuilderModal open={open} onClose={() => setOpen(false)} />
+      {open && (
+        <Suspense fallback={null}>
+          <BowlBuilderModal open={open} onClose={() => setOpen(false)} />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -116,7 +116,13 @@ export default function CartDrawer({ open, onClose }) {
                 <div className="flex items-start gap-3">
                   {/* imagen opcional */}
                   {it.image ? (
-                    <img src={it.image} alt={it.name} className="h-12 w-12 rounded-lg object-cover ring-1 ring-white/10" />
+                    <img
+                      src={it.image}
+                      alt={it.name}
+                      loading="lazy"
+                      decoding="async"
+                      className="h-12 w-12 rounded-lg object-cover ring-1 ring-white/10"
+                    />
                   ) : null}
 
                   <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- preconnect to WhatsApp domain for faster messaging links
- lazy-load images and BowlBuilder modal for better performance
- defer cart item images with lazy decoding

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8d2cee15c8327bf09b52a665b229f