### PR TITLE
feat: add global cart toast

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import { useCart } from "./context/CartContext";
 
 // Póster QR
 import QrPoster from "./components/QrPoster";
+import Toast from "./components/Toast";
 
 export default function App() {
   const [open, setOpen] = useState(false);
@@ -54,6 +55,7 @@ export default function App() {
       <GuideModal open={openGuide} onClose={() => setOpenGuide(false)}>
         <DietaryGuide />
       </GuideModal>
+      <Toast />
     </div>
   );
 }

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+
+function getCartBarHeight() {
+  try {
+    const el = document.querySelector("[data-aa-cartbar]");
+    return el ? el.offsetHeight : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export default function Toast() {
+  const [msg, setMsg] = useState("");
+  const [show, setShow] = useState(false);
+  const [offset, setOffset] = useState(0);
+
+  useEffect(() => {
+    const update = () => setOffset(getCartBarHeight());
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  useEffect(() => {
+    let hideId;
+    let offsetId;
+
+    const onToast = (e) => {
+      clearTimeout(hideId);
+      clearTimeout(offsetId);
+      const text = e?.detail?.message || "Añadido al carrito";
+      setMsg(text);
+      setShow(true);
+      const updateOffset = () => setOffset(getCartBarHeight());
+      updateOffset();
+      offsetId = setTimeout(updateOffset, 0);
+      hideId = setTimeout(() => setShow(false), 1600);
+    };
+    document.addEventListener("aa:toast", onToast);
+    return () => {
+      clearTimeout(hideId);
+      clearTimeout(offsetId);
+      document.removeEventListener("aa:toast", onToast);
+    };
+  }, []);
+
+  return (
+    <div
+      aria-live="polite"
+      className={[
+        "fixed left-1/2 -translate-x-1/2 z-[120] pointer-events-none",
+        "transition-opacity duration-200",
+        show ? "opacity-100" : "opacity-0",
+      ].join(" ")}
+      style={{ bottom: `calc(${offset}px + env(safe-area-inset-bottom, 0px) + 10px)` }}
+    >
+      <div className="rounded-full bg-[#2f4131] text-white px-4 h-9 grid place-items-center shadow-2xl ring-1 ring-black/10">
+        <span className="text-sm font-medium">{msg}</span>
+      </div>
+    </div>
+  );
+}
+
+export const toast = (message) => {
+  try {
+    document.dispatchEvent(new CustomEvent("aa:toast", { detail: { message } }));
+  } catch {}
+};
+

--- a/src/context/CartContext.jsx
+++ b/src/context/CartContext.jsx
@@ -1,6 +1,10 @@
 // src/context/CartContext.jsx
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 
+const toastEvent = (message) => {
+  try { document.dispatchEvent(new CustomEvent("aa:toast", { detail: { message } })); } catch {}
+};
+
 const toNumberCOP = (v) => {
   if (typeof v === "number") return v;
   if (!v) return 0;
@@ -71,8 +75,9 @@ export function CartProvider({ children }) {
   }, [items, hasWindow]);
 
   // API segura (siempre parte de un array)
-  function addItem(newItem) {
-    setItems((prev) => normalize([...asArray(prev), { qty: 1, ...newItem }]));
+  function addItem(payload) {
+    setItems((prev) => normalize([...asArray(prev), { qty: 1, ...payload }]));
+    setTimeout(() => toastEvent(`Añadido: ${payload?.name || "Producto"}`), 0);
   }
   function removeAt(index) {
     setItems((prev) => asArray(prev).filter((_, i) => i !== index));


### PR DESCRIPTION
## Summary
- add Toast component to show cart updates
- trigger toast from CartContext when adding items
- mount Toast once in App
- fade in/out animation and proper offset handling

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8dda3c834832783a1a11986431f24