### PR TITLE
Unifica util de stock y chips en secciones

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -104,7 +104,7 @@ export default function BowlsSection() {
           {st === "low" && (
             <StatusChip variant="low">Pocas unidades</StatusChip>
           )}
-          {disabled && <StatusChip variant="soldout">Agotado</StatusChip>}
+          {st === "out" && <StatusChip variant="soldout">Agotado</StatusChip>}
         </div>
         <div className="absolute top-5 right-5 z-10 text-neutral-800 font-bold">
           ${COP(PREBOWL.price)}

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -354,7 +354,7 @@ export default function CoffeeSection() {
                   {st === "low" && (
                     <StatusChip variant="low">Pocas unidades</StatusChip>
                   )}
-                  {disabled && (
+                  {st === "out" && (
                     <StatusChip variant="soldout">Agotado</StatusChip>
                   )}
                 </div>
@@ -402,7 +402,7 @@ export default function CoffeeSection() {
                   {st === "low" && (
                     <StatusChip variant="low">Pocas unidades</StatusChip>
                   )}
-                  {disabled && (
+                  {st === "out" && (
                     <StatusChip variant="soldout">Agotado</StatusChip>
                   )}
                 </div>

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -211,7 +211,7 @@ export function Desserts() {
                   {st === "low" && (
                     <StatusChip variant="low">Pocas unidades</StatusChip>
                   )}
-                  {disabled && (
+                  {st === "out" && (
                     <StatusChip variant="soldout">Agotado</StatusChip>
                   )}
                 </div>
@@ -269,7 +269,7 @@ function ProductRow({ item }) {
         {st === "low" && (
           <StatusChip variant="low">Pocas unidades</StatusChip>
         )}
-        {disabled && (
+        {st === "out" && (
           <StatusChip variant="soldout">Agotado</StatusChip>
         )}
       </div>

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -111,7 +111,7 @@ export default function Sandwiches() {
                 {st === "low" && (
                   <StatusChip variant="low">Pocas unidades</StatusChip>
                 )}
-                {disabled && (
+                {st === "out" && (
                   <StatusChip variant="soldout">Agotado</StatusChip>
                 )}
                 {priceByItem[it.key].unico && (

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -59,7 +59,7 @@ function List({ items, onAdd }) {
               {st === "low" && (
                 <StatusChip variant="low">Pocas unidades</StatusChip>
               )}
-              {disabled && (
+              {st === "out" && (
                 <StatusChip variant="soldout">Agotado</StatusChip>
               )}
             </div>

--- a/src/data/stock.json
+++ b/src/data/stock.json
@@ -33,6 +33,10 @@
     "post-amap": true,
     "post-vasca": false,
     "post-fresas": true,
+    "cumbre:rojos": "low",
+    "cumbre:amarillos": true,
+    "cumbre:blancos": false,
+    "cumbre:choco": "low",
 
     "cof-espresso": true,
     "cof-americano": true,
@@ -48,11 +52,5 @@
     "inf-verde": true,
     "inf-manzanilla": "low",
     "inf-chai": true
-  },
-  "cumbre": {
-    "rojos": "low",
-    "amarillos": true,
-    "blancos": false,
-    "choco": "low"
   }
 }

--- a/src/utils/stock.js
+++ b/src/utils/stock.js
@@ -1,30 +1,19 @@
-export function slugify(s = "") {
-  return s
+export const slugify = (s = "") =>
+  s
     .toLowerCase()
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");
+
+import stockdata from "../data/stock.json";
+const PRODUCTS = (stockdata?.products ?? {}) || {};
+
+export function getStockState(idOrName = "") {
+  const key = idOrName || slugify(idOrName);
+  const v = PRODUCTS[key];
+  if (v === false) return "out";
+  if (v === "low") return "low";
+  return "ok";
 }
 
-import raw from "../data/stock.json";
-const data = raw?.default || raw || {};
-const map = { ...(data.products || {}) };
-if (data.cumbre) {
-  for (const [k, v] of Object.entries(data.cumbre)) {
-    map[`cumbre:${k}`] = v;
-  }
-}
-
-export function getStockState(productIdOrName) {
-  try {
-    const id = productIdOrName || "";
-    const key = map[id] !== undefined ? id : slugify(productIdOrName || "");
-    const v = map[key];
-    if (v === false) return "out";
-    if (v === "low") return "low";
-    return "ok";
-  } catch {
-    return "ok";
-  }
-}


### PR DESCRIPTION
## Summary
- Simplifica util de stock y centraliza datos en `stock.json`
- Muestra chips de stock y deshabilita los FAB en listas de productos, café, sándwiches, smoothies y bowls

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8de64a72083278b996fd9cf50522f