### PR TITLE
feat: clear cart after sending to WhatsApp

### DIFF
--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -66,7 +66,7 @@ export default function CartDrawer({ open, onClose }) {
   const {
     items = [],
     total = 0,
-    clear: clearCart,
+    clearCart,
     increment,
     decrement,
     removeItem,
@@ -82,6 +82,27 @@ export default function CartDrawer({ open, onClose }) {
   const waHref = items?.length
     ? `https://wa.me/${waNum}?text=${buildWaText({ items, total, note })}`
     : undefined;
+
+  const onWhatsAppClick = (e) => {
+    if (!waHref) {
+      e.preventDefault();
+      return;
+    }
+    try {
+      const snapshot = { items, note, total };
+      sessionStorage.setItem("aa_last_order", JSON.stringify(snapshot));
+    } catch {}
+    setTimeout(() => {
+      try {
+        clearCart?.();
+        document.dispatchEvent(
+          new CustomEvent("aa:toast", {
+            detail: { message: "Pedido abierto en WhatsApp — Deshacer" },
+          })
+        );
+      } catch {}
+    }, 300);
+  };
 
   // setter flexible para nota por ítem (usa la disponible en el contexto)
   const setItemNote =
@@ -239,7 +260,7 @@ export default function CartDrawer({ open, onClose }) {
               href={waHref}
               target="_blank"
               rel="noreferrer"
-              onClick={(e) => { if (!waHref) e.preventDefault(); }}
+              onClick={onWhatsAppClick}
               aria-disabled={!waHref}
               className={[
                 "h-10 rounded-xl grid place-items-center",

--- a/src/context/CartContext.jsx
+++ b/src/context/CartContext.jsx
@@ -134,9 +134,30 @@ export function CartProvider({ children }) {
       return normalize(next);
     });
   }
-  function clear() {
+  function clearCart() {
     setItems([]);
+    setNote("");
   }
+
+  useEffect(() => {
+    const onUndo = () => {
+      try {
+        const raw = sessionStorage.getItem("aa_last_order");
+        if (!raw) return;
+        const snap = JSON.parse(raw);
+        snap.items?.forEach((it) => addItem?.(it));
+        setNote?.(snap.note || "");
+        sessionStorage.removeItem("aa_last_order");
+        document.dispatchEvent(
+          new CustomEvent("aa:toast", {
+            detail: { message: "Carrito restaurado" },
+          })
+        );
+      } catch {}
+    };
+    document.addEventListener("aa:undo-cart", onUndo);
+    return () => document.removeEventListener("aa:undo-cart", onUndo);
+  }, [addItem, setNote]);
 
   const { count, total } = useMemo(() => {
     const list = asArray(items);
@@ -162,7 +183,8 @@ export function CartProvider({ children }) {
     decrement,
     setQty,
     updateItem,
-    clear,
+    clear: clearCart,
+    clearCart,
     note,
     setNote,
   };


### PR DESCRIPTION
## Summary
- clear cart state and note together, with undo support via session storage
- wipe cart on WhatsApp checkout and show undo toast

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8ea606d7c8327a91f157ab556d735