### PR TITLE
feat: stabilize category bar cards and update labels

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -1,11 +1,32 @@
 import { useEffect, useRef, useState } from "react";
 import { Icon } from "@iconify-icon/react";
 import { categoryIcons } from "../data/categoryIcons";
-import { Chip } from "./Buttons";
 
 const slugify = (s) =>
-  s.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "")
-   .replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+  s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+
+function IconWithFallback({ id }) {
+  const entry = categoryIcons[id];
+  const initial = typeof entry === "string" ? entry : entry?.icon;
+  const fallback = typeof entry === "object" ? entry?.fallback : undefined;
+  const [icon, setIcon] = useState(initial);
+  if (!icon) return null;
+  return (
+    <Icon
+      icon={icon}
+      width="32"
+      height="32"
+      className="mb-2 shrink-0"
+      aria-hidden
+      onError={() => fallback && setIcon(fallback)}
+    />
+  );
+}
 
 export default function CategoryBar({ onOpenGuide }) {
   const [sections, setSections] = useState([]);
@@ -35,77 +56,76 @@ export default function CategoryBar({ onOpenGuide }) {
       (entries) => {
         for (const e of entries) if (e.isIntersecting) setActive(e.target.id);
       },
-      { root: null, rootMargin: `${marginTop}px 0px ${marginBottom}px 0px`, threshold: [0.2, 0.5] }
+      {
+        root: null,
+        rootMargin: `${marginTop}px 0px ${marginBottom}px 0px`,
+        threshold: [0.2, 0.5],
+      }
     );
     sections.forEach(({ el }) => io.observe(el));
     ioRef.current = io;
     return () => io.disconnect();
   }, [sections]);
 
-  const scrollTo = (id) => {
+  const scrollTo = (id, evt) => {
     const el = document.getElementById(id);
     if (!el || typeof window === "undefined") return;
+    el.scrollIntoView({ behavior: "smooth", block: "start" });
     const barH = barRef.current?.offsetHeight || 44;
-    window.scrollTo({
-      top: el.getBoundingClientRect().top + window.scrollY - barH - 8,
+    window.scrollBy({ top: -(barH + 8), behavior: "smooth" });
+    evt?.currentTarget?.scrollIntoView({
       behavior: "smooth",
+      inline: "nearest",
+      block: "nearest",
     });
     setActive(id);
   };
 
   return (
-    // STICKY en el WRAPPER EXTERNO (no meter overflow aquí)
     <div
       ref={barRef}
       className="sticky z-[60]"
       style={{ top: "env(safe-area-inset-top, 0px)" }}
       aria-label="Categorías del menú"
     >
-      <div className="-mx-4 sm:-mx-6 px-4 sm:px-6 py-2">
-        <div className="relative overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          <div className="flex items-stretch gap-3 w-max">
+      <div className="-mx-4 sm:-mx-6 py-2">
+        <div className="relative">
+          <div className="flex overflow-x-auto snap-x snap-mandatory px-4 gap-3 [transform:translateZ(0)] [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
             {sections.map(({ id, label }) => (
-              <Chip
+              <button
                 key={id}
-                onClick={() => scrollTo(id)}
-                active={active === id}
-                shape="card"
+                onClick={(e) => scrollTo(id, e)}
                 aria-current={active === id ? "true" : undefined}
                 className={[
-                  "flex-none flex flex-col items-center justify-center",
-                  "h-18 w-[96px] px-3 py-2",
-
-                  "text-[12px] leading-tight text-center whitespace-normal break-words",
+                  "flex-none shrink-0 basis-[112px] w-[112px] h-[128px] snap-start",
+                  "flex flex-col items-center justify-center",
+                  "rounded-xl border bg-white/70 backdrop-blur-sm",
+                  "text-[12px] leading-tight text-center text-[#2f4131]",
                   active === id
-                    ? "shadow-sm"
-                    : "bg-white/90 border-[#2f4131]/35 text-[#2f4131] hover:border-[#2f4131]/60"
+                    ? "border-[#2f4131] bg-[#2f4131] text-white"
+                    : "border-[#2f4131]/35 hover:border-[#2f4131]/60",
                 ].join(" ")}
               >
-                <Icon
-                  icon={categoryIcons[id] || "fluent-emoji:white-circle"}
-                  width="28"
-                  height="28"
-                  className="mb-1 shrink-0"
-                  aria-hidden
-                />
-                <span className="w-full">{label}</span>
-
-              </Chip>
+                <IconWithFallback id={id} />
+                <span className="w-full h-[38px] line-clamp-2">{label}</span>
+              </button>
             ))}
 
-            {/* Botón Alérgenos en el mismo estilo */}
-            <Chip
+            <button
               onClick={onOpenGuide}
-              shape="card"
-              className="flex-none flex flex-col items-center justify-center h-18 w-[96px] px-3 py-2 text-[12px] leading-tight text-center bg-white/90 border-[#2f4131]/35 text-[#2f4131] hover:bg-[#2f4131] hover:text-white"
+              className="flex-none shrink-0 basis-[112px] w-[112px] h-[128px] snap-start flex flex-col items-center justify-center rounded-xl border bg-white/70 backdrop-blur-sm text-[12px] leading-tight text-center text-[#2f4131] border-[#2f4131]/35 hover:border-[#2f4131]/60"
             >
-              <Icon icon="fluent-emoji:microbe" width="28" height="28" className="mb-1" aria-hidden />
-              <span className="w-full">Alérgenos</span>
-
-            </Chip>
+              <Icon
+                icon="fluent-emoji:microbe"
+                width="32"
+                height="32"
+                className="mb-2 shrink-0"
+                aria-hidden
+              />
+              <span className="w-full h-[38px] line-clamp-2">Alérgenos</span>
+            </button>
           </div>
 
-          {/* Fades sutiles para insinuar scroll, ajustados al fondo de la app */}
           <div className="pointer-events-none absolute inset-y-0 left-0 w-6 bg-gradient-to-r from-[#efe8de]/85 to-transparent" />
           <div className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-[#efe8de]/85 to-transparent" />
         </div>
@@ -113,4 +133,3 @@ export default function CategoryBar({ onOpenGuide }) {
     </div>
   );
 }
-

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -22,16 +22,16 @@ export default function ProductLists({ setOpenGuide }) {
       <Section title="Bowls">
         <BowlsSection />
       </Section>
-      <Section title="Platos Fuertes">
+      <Section title="Platos">
         <Mains />
       </Section>
       <Section title="Sándwiches">
         <Sandwiches />
       </Section>
-      <Section title="Smoothies & Funcionales">
+      <Section title="Smoothies">
         <SmoothiesSection />
       </Section>
-      <Section title="Café de especialidad">
+      <Section title="Café">
         <CoffeeSection />
       </Section>
       <ColdDrinksSection />

--- a/src/data/categoryIcons.js
+++ b/src/data/categoryIcons.js
@@ -1,10 +1,16 @@
 export const categoryIcons = {
   desayunos: "fluent-emoji:croissant",
   bowls: "fluent-emoji:pot-of-food",
-  "platos-fuertes": "fluent-emoji:fork-and-knife-with-plate",
+  platos: "fluent-emoji:fork-and-knife-with-plate",
   sandwiches: "fluent-emoji:sandwich",
-  smoothies: "fluent-emoji:tropical-drink",
-  cafes: "fluent-emoji:hot-beverage",
+  smoothies: {
+    icon: "fluent-emoji:cup-with-straw",
+    fallback: "noto:bubble-tea",
+  },
+  cafe: {
+    icon: "fluent-emoji:hot-beverage",
+    fallback: "noto:hot-beverage",
+  },
   postres: "fluent-emoji:shortcake",
   "bebidas-frias": "fluent-emoji:ice",
 };


### PR DESCRIPTION
## Summary
- stabilize category cards and allergens button with fixed sizing and snapping
- shorten menu section names and keep observer scroll handling
- refresh category icon config with new 3D icons and fallbacks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "@iconify-icon/react" from src/components/Header.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a916881a4883278bd22c41a8491657