### PR TITLE
feat: reordenar home y estilizar carrusel de promos

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Header from "./components/Header";
 import Footer from "./components/Footer";
 import ProductLists from "./components/ProductLists";
 import SearchBar from "./components/SearchBar";
+import PromoBannerCarousel from "./components/PromoBannerCarousel";
 import GuideModal from "./components/GuideModal";
 import DietaryGuide from "./components/DietaryGuide";
 
@@ -13,6 +14,7 @@ import DietaryGuide from "./components/DietaryGuide";
 import FloatingCartBar from "./components/FloatingCartBar";
 import CartDrawer from "./components/CartDrawer";
 import { useCart } from "./context/CartContext";
+import { banners as buildBanners } from "./data/banners";
 
 // Póster QR
 import QrPoster from "./components/QrPoster";
@@ -24,6 +26,7 @@ export default function App() {
   const [query, setQuery] = useState("");
   const [activeCategoryId, setActiveCategoryId] = useState(null);
   const cart = useCart();
+  const banners = buildBanners(import.meta.env);
 
   // ✅ Modo póster QR (?qr=1) – se muestra SOLO el QR
   const isQr = (() => {
@@ -45,6 +48,7 @@ export default function App() {
         <div className="mb-6">
           <SearchBar value={query} onQueryChange={setQuery} />
         </div>
+        <PromoBannerCarousel banners={banners} />
         <ProductLists
           query={query}
           activeCategoryId={activeCategoryId}

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -10,11 +10,8 @@ import CoffeeSection from "./CoffeeSection";
 import BowlsSection from "./BowlsSection";
 import ColdDrinksSection from "./ColdDrinksSection";
 import CategoryBar from "./CategoryBar";
-import PromoBannerCarousel from "./PromoBannerCarousel";
-import { banners as buildBanners } from "../data/banners";
 
 export default function ProductLists({ query, activeCategoryId, onCategorySelect }) {
-  const banners = buildBanners(import.meta.env);
 
   const categories = [
     { id: "desayunos", label: "Desayunos" },
@@ -56,7 +53,6 @@ export default function ProductLists({ query, activeCategoryId, onCategorySelect
         activeId={activeCategoryId}
         onSelect={(cat) => onCategorySelect?.(cat)}
       />
-      <PromoBannerCarousel banners={banners} />
       {sections.map((s) => (
         <div key={s.id}>{s.node}</div>
       ))}

--- a/src/components/PromoBannerCarousel.jsx
+++ b/src/components/PromoBannerCarousel.jsx
@@ -45,9 +45,18 @@ export default function PromoBannerCarousel({ banners = [] }) {
   };
 
   return (
-    <div className="mt-4" aria-roledescription="carousel">
+    <div
+      className="mt-4 -mx-5 sm:-mx-6 md:-mx-8 px-5 sm:px-6 md:px-8 bg-gradient-to-b from-alto-beige to-transparent"
+      aria-roledescription="carousel"
+    >
       <div
         className="relative overflow-hidden rounded-2xl"
+        style={{
+          maskImage:
+            "linear-gradient(to right, transparent, black 8%, black 92%, transparent)",
+          WebkitMaskImage:
+            "linear-gradient(to right, transparent, black 8%, black 92%, transparent)",
+        }}
         onMouseEnter={() => setPaused(true)}
         onMouseLeave={() => setPaused(false)}
         onTouchStart={onTouchStart}


### PR DESCRIPTION
## Summary
- Muestra el carrusel de banners justo después de la barra de búsqueda y antes de las categorías
- Añade degradado de fondo y desvanecido lateral al carrusel promocional
- Limpia ProductLists para que solo renderice CategoryBar y las secciones

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a924b6a8948327ba1211c49f4a1ee4