### PR TITLE
feat: add chip variant to CategoryBar

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Icon } from "@iconify-icon/react";
 import { categoryIcons } from "../data/categoryIcons";
 
-function IconWithFallback({ id }) {
+function IconWithFallback({ id, size = 32, className }) {
   const entry = categoryIcons[id];
   const initial = typeof entry === "string" ? entry : entry?.icon;
   const fallback = typeof entry === "object" ? entry?.fallback : undefined;
@@ -11,16 +11,27 @@ function IconWithFallback({ id }) {
   return (
     <Icon
       icon={icon}
-      width="32"
-      height="32"
-      className="mb-2 shrink-0"
+      width={size}
+      height={size}
+      className={className}
       aria-hidden
       onError={() => fallback && setIcon(fallback)}
     />
   );
 }
 
-export default function CategoryBar({ categories = [], activeId, onSelect }) {
+export default function CategoryBar({
+  categories = [],
+  activeId,
+  onSelect,
+  variant = "chip",
+}) {
+  const baseItemClasses =
+    variant === "chip"
+      ? "flex-none basis-[96px] w-[96px] h-[104px]"
+      : "flex-none shrink-0 basis-[112px] w-[112px] h-[128px]";
+  const labelHeight = variant === "chip" ? "h-[34px]" : "h-[38px]";
+
   return (
     <div
       className="sticky z-[60]"
@@ -41,15 +52,22 @@ export default function CategoryBar({ categories = [], activeId, onSelect }) {
                   target?.scrollIntoView({ behavior: "smooth", block: "start" });
                   onSelect?.(cat);
                 }}
-                className={`flex-none shrink-0 basis-[112px] w-[112px] h-[128px] rounded-xl border bg-white/70 backdrop-blur-sm snap-start transition-colors flex flex-col items-center justify-center text-[12px] leading-tight text-center ${
+                aria-current={active ? "true" : undefined}
+                className={`${baseItemClasses} snap-start rounded-xl border bg-white/70 backdrop-blur-sm transition-colors flex flex-col items-center justify-center text-[12px] leading-tight text-center ${
                   active
                     ? "bg-[#2f4131]/5 text-[#2f4131] border-[#2f4131]"
-                    : "text-[#2f4131] border-[#2f4131]/35 hover:border-[#2f4131]/60"
+                    : "text-[#2f4131] border-[#2f4131]/35 hover:border-[#2f4131]/60 focus:border-[#2f4131]/60"
                 }`}
               >
-                <IconWithFallback id={cat.id} />
+                {variant === "chip" ? (
+                  <span className="mb-2 flex items-center justify-center w-10 h-10 rounded-full bg-alto-greige/50">
+                    <IconWithFallback id={cat.id} className="shrink-0" />
+                  </span>
+                ) : (
+                  <IconWithFallback id={cat.id} className="mb-2 shrink-0" />
+                )}
                 <span
-                  className="w-full h-[38px] overflow-hidden"
+                  className={`w-full ${labelHeight} overflow-hidden`}
                   style={{
                     display: "-webkit-box",
                     WebkitLineClamp: 2,

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -55,6 +55,7 @@ export default function ProductLists({ query, activeCategoryId, onCategorySelect
         categories={categories}
         activeId={activeCategoryId}
         onSelect={(cat) => onCategorySelect?.(cat)}
+        variant="chip"
       />
       <PromoBannerCarousel banners={banners} />
       {sections.map((s) => (


### PR DESCRIPTION
## Summary
- add `variant` prop to CategoryBar with chip and card styles
- style chip variant with fixed size, circular icon background, line-clamped labels, and active `aria-current`
- use chip variant for home product lists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a924d10074832791462fb10212a49b