### PR TITLE
feat: add hero headline above search

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Header from "./components/Header";
 import Footer from "./components/Footer";
 import ProductLists from "./components/ProductLists";
 import SearchBar from "./components/SearchBar";
+import HeroHeadline from "./components/HeroHeadline";
 import PromoBannerCarousel from "./components/PromoBannerCarousel";
 import GuideModal from "./components/GuideModal";
 import DietaryGuide from "./components/DietaryGuide";
@@ -46,6 +47,7 @@ export default function App() {
 
       <div className="mx-auto max-w-3xl p-5 sm:p-6 md:p-8">
         <div className="mb-6">
+          <HeroHeadline />
           <SearchBar value={query} onQueryChange={setQuery} />
         </div>
         <PromoBannerCarousel banners={banners} />

--- a/src/components/HeroHeadline.jsx
+++ b/src/components/HeroHeadline.jsx
@@ -1,0 +1,21 @@
+export default function HeroHeadline() {
+  return (
+    <section aria-labelledby="home-headline" className="mb-3 md:mb-4">
+      <h1
+        id="home-headline"
+        tabIndex="-1"
+        className="text-[22px] md:text-3xl font-semibold tracking-tight focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(47,65,49,.3)] rounded"
+        style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}
+      >
+        <span className="sr-only">Alto Andino</span>
+        <span className="headline-strong bg-gradient-to-r from-[#2f4131] via-[#3b5b48] to-[#7aa28d] bg-clip-text text-transparent">
+          Comer sano
+        </span>{" "}
+        nunca fue tan fácil
+      </h1>
+      <p className="headline-sub text-sm md:text-base text-zinc-600">
+        Ingredientes locales y de temporada · Pet friendly
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add HeroHeadline component with gradient brand styling
- show headline above SearchBar on home page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a926e466d08327b2fb3e23b2c29ef2