### PR TITLE
refactor: adjust green gradient in hero headline

### DIFF
--- a/src/components/HeroHeadline.jsx
+++ b/src/components/HeroHeadline.jsx
@@ -8,7 +8,7 @@ export default function HeroHeadline() {
         style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}
       >
         <span className="sr-only">Alto Andino</span>
-        <span className="headline-strong bg-gradient-to-r from-[#2f4131] via-[#3b5b48] to-[#7aa28d] bg-clip-text text-transparent">
+        <span className="headline-strong bg-gradient-to-r from-[#2f4131] via-[#3e5f4b] to-[#7aa28d] bg-clip-text text-transparent">
           Comer sano
         </span>{" "}
         nunca fue tan fácil


### PR DESCRIPTION
## Summary
- update `Comer sano` hero headline to use subtle all-green gradient for text

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a92988d7a483278f94c4baa97ecc45