### PR TITLE
Add category header above category bar

### DIFF
--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -1,0 +1,18 @@
+export default function CategoryHeader() {
+  return (
+    <section
+      aria-labelledby="cat-title"
+      className="px-4 md:px-6 mt-3 md:mt-4 mb-2 md:mb-3"
+    >
+      <h2
+        id="cat-title"
+        className="text-lg md:text-xl font-semibold tracking-tight text-[#2f4131]"
+      >
+        Explora por categoría
+      </h2>
+      <p className="text-sm md:text-[15px] text-zinc-600">
+        Elige una categoría o desliza para ver más →
+      </p>
+    </section>
+  );
+}

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -11,6 +11,7 @@ import CoffeeSection from "./CoffeeSection";
 import BowlsSection from "./BowlsSection";
 import ColdDrinksSection from "./ColdDrinksSection";
 import CategoryBar from "./CategoryBar";
+import CategoryHeader from "./CategoryHeader";
 
 export default function ProductLists({ query, activeCategoryId, onCategorySelect }) {
 
@@ -71,6 +72,7 @@ export default function ProductLists({ query, activeCategoryId, onCategorySelect
 
   return (
     <>
+      <CategoryHeader />
       <CategoryBar
         categories={categories}
         activeId={activeCategoryId}

--- a/src/components/PromoBannerCarousel.jsx
+++ b/src/components/PromoBannerCarousel.jsx
@@ -135,11 +135,10 @@ export default function PromoBannerCarousel({ banners = [], resolveProductById }
                   className="absolute top-3 right-3 md:top-4 md:right-4 rounded-full px-3 py-1 text-sm bg-white/85 backdrop-blur text-[#2f4131] font-medium"
                 >
                   {cop(b.price)}
-
                 </div>
-              </div>
-            );
-          })}
+              )}
+            </div>
+          ))}
 
         </div>
         <div className="absolute bottom-2 left-0 right-0 flex justify-center gap-2">


### PR DESCRIPTION
## Summary
- add `CategoryHeader` component with heading and subtitle
- render new header before `CategoryBar` in product list
- fix promo banner price block markup to keep build green

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a92ac4e1508327bd9425e25b52143a