### PR TITLE
feat: neumorphic active state for category chips

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -28,7 +28,7 @@ export default function CategoryBar({
 }) {
   const baseItemClasses =
     variant === "chip"
-      ? "flex-none w-[100px] basis-[100px] h-[110px] snap-start rounded-xl border bg-white/70 backdrop-blur-sm"
+      ? "flex-none w-[100px] basis-[100px] h-[110px] snap-start rounded-xl bg-white/60 backdrop-blur-sm transition-colors transition-shadow duration-150 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,.3)] focus:ring-offset-2"
       : "flex-none shrink-0 basis-[112px] w-[112px] h-[128px]";
   const labelHeight = variant === "chip" ? "h-[34px]" : "h-[38px]";
 
@@ -57,22 +57,28 @@ export default function CategoryBar({
                   target?.scrollIntoView({ behavior: "smooth", block: "start" });
                   onSelect?.(cat);
                 }}
+                type="button"
+                aria-label={cat.label}
                 aria-current={active ? "true" : undefined}
-                className={`${baseItemClasses} flex flex-col items-center justify-center text-center transition-colors ${
+                className={`${baseItemClasses} flex flex-col items-center justify-center text-center ${
                   active
-                    ? "bg-[#2f4131]/5 border-[#2f4131] text-[#2f4131]"
+                    ? "border border-transparent bg-white/55 shadow-[inset_0_1px_0_rgba(255,255,255,.65),_0_8px_22px_rgba(36,51,38,.16)] text-[#2f4131]"
                     : variant === "chip"
-                    ? "border-zinc-200 hover:border-zinc-300"
+                    ? "border border-zinc-200 hover:border-zinc-300"
                     : "text-[#2f4131] border-[#2f4131]/35 hover:border-[#2f4131]/60 focus:border-[#2f4131]/60"
                 }`}
               >
                 {variant === "chip" ? (
                   <span
-                    className={`grid place-items-center h-11 w-11 md:h-12 md:w-12 rounded-full ${tint}`}
+                    className={`grid place-items-center h-11 w-11 md:h-12 md:w-12 rounded-full ${tint} ${
+                      active ? "shadow-[inset_0_1px_0_rgba(255,255,255,.75)]" : ""
+                    }`}
                   >
                     <IconWithFallback
                       id={cat.id}
-                      className="h-6 w-6 md:h-7 md:w-7 shrink-0"
+                      className={`h-6 w-6 md:h-7 md:w-7 shrink-0 ${
+                        active ? "text-[#2f4131]" : ""
+                      }`}
                     />
                   </span>
                 ) : (


### PR DESCRIPTION
## Summary
- Restyle CategoryBar chip variant with translucent neumorphic active state
- Tint active icons and labels; add focus ring and accessibility attributes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9345d2a908327b9781e88b9c886c0