### PR TITLE
refactor: memoize product lookup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 // src/App.jsx
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 // Layout / UI
 import Header from "./components/Header";
@@ -34,8 +34,7 @@ export default function App() {
   const cart = useCart();
   const banners = buildBanners(import.meta.env);
 
-  function resolveProductById(id) {
-    if (!id) return null;
+  const productMap = useMemo(() => {
     const collections = [
       BREAKFAST_ITEMS,
       MAINS_ITEMS,
@@ -56,12 +55,13 @@ export default function App() {
       });
       collections.push(mapped);
     }
+    const map = {};
     for (const col of collections) {
       if (!Array.isArray(col)) continue;
-      const p = col.find((x) => x.id === id || x.productId === id);
-      if (p) {
+      for (const p of col) {
         const pid = p.id || p.productId;
-        return {
+        if (!pid) continue;
+        const prod = {
           ...p,
           id: pid,
           productId: pid,
@@ -71,9 +71,32 @@ export default function App() {
           price: p.price,
           image: p.image,
         };
+        const ids = [p.id, p.productId].filter(Boolean);
+        if (ids.length === 0) ids.push(pid);
+        for (const ident of ids) {
+          map[ident] = prod;
+        }
       }
     }
-    return null;
+    return map;
+  }, [
+    BREAKFAST_ITEMS,
+    MAINS_ITEMS,
+    DESSERT_BASE_ITEMS,
+    PREBOWL,
+    smoothies,
+    funcionales,
+    COFFEES,
+    INFUSIONS,
+    SODAS,
+    OTHERS,
+    sandwichItems,
+    sandwichPriceByItem,
+  ]);
+
+  function resolveProductById(id) {
+    if (!id) return null;
+    return productMap[id] || null;
   }
 
   // ✅ Modo póster QR (?qr=1) – se muestra SOLO el QR


### PR DESCRIPTION
## Summary
- build memoized product map of all collections
- use direct map lookup instead of looping in resolveProductById

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: BREAKFAST_ITEMS is not exported by src/components/ProductLists.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a93ad18a208327be34a7b6e9b328ce