### PR TITLE
Include meal item collections in product map

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,11 @@ import { useMemo, useState } from "react";
 // Layout / UI
 import Header from "./components/Header";
 import Footer from "./components/Footer";
-import ProductLists from "./components/ProductLists";
+import ProductLists, {
+  BREAKFAST_ITEMS,
+  MAINS_ITEMS,
+  DESSERT_BASE_ITEMS,
+} from "./components/ProductLists";
 import SearchBar from "./components/SearchBar";
 import HeroHeadline from "./components/HeroHeadline";
 import PromoBannerCarousel from "./components/PromoBannerCarousel";
@@ -36,6 +40,9 @@ export default function App() {
 
   const productMap = useMemo(() => {
     const collections = [
+      BREAKFAST_ITEMS,
+      MAINS_ITEMS,
+      DESSERT_BASE_ITEMS,
       [PREBOWL],
       smoothies,
       funcionales,


### PR DESCRIPTION
## Summary
- import breakfast, mains, and dessert product arrays from `ProductLists`
- extend `productMap` collections with breakfast, mains, and dessert items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a93e7dfb2c83279cdf9172ea054b2b