### PR TITLE
Add reusable error boundary

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, info) {
+    // You can log error details to an error reporting service here
+    console.error("ErrorBoundary caught an error", error, info);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+    if (typeof this.props.onRetry === "function") {
+      this.props.onRetry();
+    }
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center p-4 text-center">
+          <p className="mb-4 text-red-600">Something went wrong.</p>
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,11 +5,14 @@ import App from "./App.jsx";
 import "./styles.css";
 import "./index.css";
 import { CartProvider } from "./context/CartContext";
+import ErrorBoundary from "./components/ErrorBoundary.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <CartProvider>
-      <App />
-    </CartProvider>
+    <ErrorBoundary>
+      <CartProvider>
+        <App />
+      </CartProvider>
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- implement reusable `ErrorBoundary` component with fallback UI
- wrap app tree with `ErrorBoundary`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a93e7fb26c8327a6d921f0df8198fa