### PR TITLE
feat: restore categories header

### DIFF
--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -10,6 +10,7 @@ import SmoothiesSection from "./SmoothiesSection";
 import CoffeeSection from "./CoffeeSection";
 import BowlsSection from "./BowlsSection";
 import ColdDrinksSection from "./ColdDrinksSection";
+import CategoryHeader from "./CategoryHeader";
 import CategoryBar from "./CategoryBar";
 import FeaturedToday from "./FeaturedToday";
 
@@ -228,6 +229,7 @@ export default function ProductLists({
 
   return (
     <>
+      <CategoryHeader />
       <CategoryBar
         categories={categories}
         activeId={activeCategoryId}


### PR DESCRIPTION
## Summary
- add category header component and text
- show category bar after header on home

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a940018fd88327a5b326dc185a4bdb