### PR TITLE
Improve hero headline contrast

### DIFF
--- a/src/components/HeroHeadline.jsx
+++ b/src/components/HeroHeadline.jsx
@@ -8,7 +8,10 @@ export default function HeroHeadline() {
         style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}
       >
         <span className="sr-only">Alto Andino</span>
-        <span className="headline-strong bg-gradient-to-r from-[#2f4131] via-[#3e5f4b] to-[#7aa28d] bg-clip-text text-transparent">
+        <span
+          className="bg-gradient-to-r from-[#203628] to-[#5f8a74] bg-clip-text text-transparent"
+          style={{ textShadow: '0 1px 0 rgba(0,0,0,.18)' }}
+        >
           Comer sano
         </span>{" "}
         nunca fue tan fácil


### PR DESCRIPTION
## Summary
- increase contrast of "Comer sano" headline with dark green gradient
- add subtle text shadow for better readability

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad2797656483279aa6047e17ff8c27