### PR TITLE
feat: add deep link support for tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 // src/App.jsx
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 // Layout / UI
 import Header from "./components/Header";
@@ -8,6 +8,7 @@ import ProductLists, {
   BREAKFAST_ITEMS,
   MAINS_ITEMS,
   DESSERT_BASE_ITEMS,
+  CATS,
 } from "./components/ProductLists";
 import SearchBar from "./components/SearchBar";
 import HeroHeadline from "./components/HeroHeadline";
@@ -37,6 +38,29 @@ export default function App() {
   const [selectedCategory, setSelectedCategory] = useState("todos");
   const cart = useCart();
   const banners = buildBanners(import.meta.env);
+
+  function handleCategorySelect(cat) {
+    const slug = typeof cat === "string" ? cat : cat.id;
+    const url = new URL(window.location.href);
+    url.searchParams.set("cat", slug);
+    window.history.replaceState(null, "", url);
+    setSelectedCategory(slug);
+    if (slug !== "todos") {
+      const panelId = `panel-${slug}`;
+      requestAnimationFrame(() => {
+        document.getElementById(panelId)?.focus();
+      });
+    }
+  }
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const slug = params.get("cat");
+    const valid = ["todos", ...CATS];
+    if (slug && valid.includes(slug)) {
+      handleCategorySelect(slug);
+    }
+  }, []);
 
   const productMap = useMemo(() => {
     const collections = [
@@ -128,7 +152,7 @@ export default function App() {
         <ProductLists
           query={query}
           selectedCategory={selectedCategory}
-          onCategorySelect={(cat) => setSelectedCategory(cat.id)}
+          onCategorySelect={handleCategorySelect}
         />
 
         <Footer />

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -17,7 +17,7 @@ import { categoryIcons } from "../data/categoryIcons";
 
 const FEATURE_TABS = import.meta.env.VITE_FEATURE_TABS === "1";
 
-const CATS = [
+export const CATS = [
   "desayunos",
   "bowls",
   "platos",
@@ -247,6 +247,18 @@ export default function ProductLists({
     [query]
   );
 
+  const renderPanel = (s) => (
+    <div
+      key={s.id}
+      id={`panel-${s.id}`}
+      role="tabpanel"
+      tabIndex={-1}
+      aria-labelledby={`tab-${s.id}`}
+    >
+      {s.element}
+    </div>
+  );
+
   useEffect(() => {
     if (!FEATURE_TABS) return;
     const valid = ["todos", ...CATS];
@@ -284,11 +296,11 @@ export default function ProductLists({
       </div>
       {FEATURE_TABS
         ? selectedCategory === "todos"
-          ? sections.map((s) => <div key={s.id}>{s.element}</div>)
+          ? sections.map(renderPanel)
           : sections
               .filter((s) => s.id === selectedCategory)
-              .map((s) => <div key={s.id}>{s.element}</div>)
-        : sections.map((s) => <div key={s.id}>{s.element}</div>)}
+              .map(renderPanel)
+        : sections.map(renderPanel)}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- read `cat` query param on mount to set initial category
- update `cat` param and focus tab panels when switching categories
- export category slugs for validation and give each panel an id for accessibility

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad2cb19fb4832796dc3fad8d2fa488