### PR TITLE
feat: show counts per menu category

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -25,6 +25,7 @@ export default function CategoryBar({
   activeId,
   onSelect,
   variant = "chip",
+  counts = {},
 }) {
   const baseItemClasses =
     variant === "chip"
@@ -88,14 +89,22 @@ export default function CategoryBar({
                   }`}
                 >
                   <span
-                    className={labelTextClasses}
-                    style={{
-                      display: "-webkit-box",
-                      WebkitLineClamp: 2,
-                      WebkitBoxOrient: "vertical",
-                    }}
+                    className={`${labelTextClasses} flex items-center justify-center`}
                   >
-                    {cat.label}
+                    <span
+                      style={{
+                        display: "-webkit-box",
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: "vertical",
+                      }}
+                    >
+                      {cat.label}
+                    </span>
+                    {counts[cat.id] != null && (
+                      <span className="min-w-[22px] h-[22px] text-[12px] rounded-full bg-[#2f4131] text-white grid place-items-center ml-1">
+                        {counts[cat.id]}
+                      </span>
+                    )}
                   </span>
                 </span>
               </button>

--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -18,7 +18,7 @@ function IconWithFallback({ icon, size = 32, className }) {
   );
 }
 
-export default function CategoryTabs({ value, onChange, items = [] }) {
+export default function CategoryTabs({ value, onChange, items = [], counts = {} }) {
   const tabRefs = useRef([]);
   const baseItemClasses =
     "flex-none w-[100px] basis-[100px] h-[110px] snap-start rounded-xl bg-white/60 backdrop-blur-sm transition-colors transition-shadow duration-150 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,.3)] focus:ring-offset-2";
@@ -95,16 +95,24 @@ export default function CategoryTabs({ value, onChange, items = [] }) {
               </span>
               <span className="w-full h-[34px] overflow-hidden mt-2">
                 <span
-                  className={`text-[13px] leading-tight ${
+                  className={`text-[13px] leading-tight flex items-center justify-center ${
                     selected ? "text-[#2f4131]" : "text-zinc-800"
                   }`}
-                  style={{
-                    display: "-webkit-box",
-                    WebkitLineClamp: 2,
-                    WebkitBoxOrient: "vertical",
-                  }}
                 >
-                  {item.label}
+                  <span
+                    style={{
+                      display: "-webkit-box",
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: "vertical",
+                    }}
+                  >
+                    {item.label}
+                  </span>
+                  {counts[item.id] != null && (
+                    <span className="min-w-[22px] h-[22px] text-[12px] rounded-full bg-[#2f4131] text-white grid place-items-center ml-1">
+                      {counts[item.id]}
+                    </span>
+                  )}
                 </span>
               </span>
             </button>

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -143,6 +143,7 @@ export default function ProductLists({
   query,
   selectedCategory,
   onCategorySelect,
+  counts = {},
 }) {
   const categories = useMemo(
     () => [
@@ -276,6 +277,7 @@ export default function ProductLists({
           <CategoryTabs
             items={tabItems}
             value={selectedCategory}
+            counts={counts}
             onChange={(slug) => {
               if (slug === "todos") {
                 onCategorySelect?.({ id: "todos" });
@@ -291,6 +293,7 @@ export default function ProductLists({
             activeId={selectedCategory}
             onSelect={onCategorySelect}
             variant="chip"
+            counts={counts}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- compute available product counts per category on home screen
- display count badges in category tabs and category bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad2df19460832788e936b7673851d0