### PR TITLE
feat: add swipe gestures for category tabs

### DIFF
--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -14,6 +14,7 @@ import CategoryHeader from "./CategoryHeader";
 import CategoryBar from "./CategoryBar";
 import CategoryTabs from "./CategoryTabs";
 import { categoryIcons } from "../data/categoryIcons";
+import useSwipeTabs from "../utils/useSwipeTabs";
 
 const FEATURE_TABS = import.meta.env.VITE_FEATURE_TABS === "1";
 
@@ -267,6 +268,33 @@ export default function ProductLists({
     }
   }, [selectedCategory, onCategorySelect]);
 
+  const orderedTabs = ["todos", ...CATS];
+  const swipeHandlers = useSwipeTabs({
+    onPrev: () => {
+      const idx = orderedTabs.indexOf(selectedCategory);
+      if (idx > 0) {
+        const prev = orderedTabs[idx - 1];
+        if (prev === "todos") {
+          onCategorySelect?.({ id: "todos" });
+        } else {
+          const cat = categories.find((c) => c.id === prev);
+          onCategorySelect?.(cat ?? { id: prev });
+        }
+      }
+    },
+    onNext: () => {
+      const idx = orderedTabs.indexOf(selectedCategory);
+      if (idx >= 0 && idx < orderedTabs.length - 1) {
+        const nxt = orderedTabs[idx + 1];
+        if (nxt === "todos") {
+          onCategorySelect?.({ id: "todos" });
+        } else {
+          const cat = categories.find((c) => c.id === nxt);
+          onCategorySelect?.(cat ?? { id: nxt });
+        }
+      }
+    },
+  });
 
   return (
     <>
@@ -294,13 +322,15 @@ export default function ProductLists({
           />
         )}
       </div>
-      {FEATURE_TABS
-        ? selectedCategory === "todos"
-          ? sections.map(renderPanel)
-          : sections
-              .filter((s) => s.id === selectedCategory)
-              .map(renderPanel)
-        : sections.map(renderPanel)}
+      <div {...swipeHandlers}>
+        {FEATURE_TABS
+          ? selectedCategory === "todos"
+            ? sections.map(renderPanel)
+            : sections
+                .filter((s) => s.id === selectedCategory)
+                .map(renderPanel)
+          : sections.map(renderPanel)}
+      </div>
     </>
   );
 }

--- a/src/utils/useSwipeTabs.js
+++ b/src/utils/useSwipeTabs.js
@@ -1,0 +1,42 @@
+import { useRef } from "react";
+
+export default function useSwipeTabs({ onPrev, onNext, threshold = 40 } = {}) {
+  const startX = useRef(0);
+  const startY = useRef(0);
+  const triggered = useRef(false);
+
+  function onTouchStart(e) {
+    const t = e.touches && e.touches[0];
+    if (!t) return;
+    startX.current = t.clientX;
+    startY.current = t.clientY;
+    triggered.current = false;
+  }
+
+  function onTouchMove(e) {
+    if (triggered.current) return;
+    const t = e.touches && e.touches[0];
+    if (!t) return;
+    const dx = t.clientX - startX.current;
+    const dy = t.clientY - startY.current;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > threshold) {
+      triggered.current = true;
+      if (dx > 0) {
+        onPrev?.();
+      } else {
+        onNext?.();
+      }
+    }
+  }
+
+  function onTouchEnd() {
+    triggered.current = false;
+  }
+
+  return {
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add hook to detect horizontal swipes
- enable changing product category with swipe gestures

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad2e62510c832784f1b7cbfff651b5