### PR TITLE
feat: make category bar full-bleed

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -38,7 +38,7 @@ export default function CategoryBar({
       style={{ top: "env(safe-area-inset-top, 0px)" }}
       aria-label="Categorías del menú"
     >
-      <ul className="flex overflow-x-auto snap-x snap-mandatory gap-3 scroll-px-4 py-2 [transform:translateZ(0)]">
+      <ul className="flex overflow-x-auto snap-x snap-mandatory gap-3 py-2 [transform:translateZ(0)]">
         {categories.map((cat) => {
           const active = activeId === cat.id;
           const tint = cat.tintClass || "bg-zinc-100";

--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -59,7 +59,7 @@ export default function CategoryTabs({ value, onChange, items = [], counts = {} 
     >
       <div
         role="tablist"
-        className="flex overflow-x-auto snap-x snap-mandatory gap-3 scroll-px-4 py-2 [transform:translateZ(0)]"
+        className="flex overflow-x-auto snap-x snap-mandatory gap-3 py-2 [transform:translateZ(0)]"
       >
         {items.map((item, idx) => {
           const selected = value === item.id;
@@ -75,7 +75,7 @@ export default function CategoryTabs({ value, onChange, items = [], counts = {} 
               tabIndex={selected ? 0 : -1}
               onKeyDown={(e) => handleKeyDown(e, idx)}
               onClick={() => onChange?.(item.id)}
-              className={`${baseItemClasses} flex flex-col items-center justify-center text-center ${
+              className={`${baseItemClasses} first:ml-1 last:mr-1 flex flex-col items-center justify-center text-center ${
                 selected
                   ? "border border-transparent bg-white/55 shadow-[inset_0_1px_0_rgba(255,255,255,.65),_0_8px_22px_rgba(36,51,38,.16)] text-[#2f4131]"
                   : "border border-zinc-200 hover:border-zinc-300"

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -301,29 +301,31 @@ export default function ProductLists({
     <>
       <div className="mx-auto max-w-screen-md px-4 md:px-6">
         <CategoryHeader />
-        {FEATURE_TABS ? (
-          <CategoryTabs
-            items={tabItems}
-            value={selectedCategory}
-            counts={counts}
-            onChange={(slug) => {
-              if (slug === "todos") {
-                onCategorySelect?.({ id: "todos" });
-              } else {
-                const cat = categories.find((c) => c.id === slug);
-                onCategorySelect?.(cat ?? { id: "todos" });
-              }
-            }}
-          />
-        ) : (
-          <CategoryBar
-            categories={categories}
-            activeId={selectedCategory}
-            onSelect={onCategorySelect}
-            variant="chip"
-            counts={counts}
-          />
-        )}
+        <div className="-mx-4 md:-mx-6 px-4 md:px-6">
+          {FEATURE_TABS ? (
+            <CategoryTabs
+              items={tabItems}
+              value={selectedCategory}
+              counts={counts}
+              onChange={(slug) => {
+                if (slug === "todos") {
+                  onCategorySelect?.({ id: "todos" });
+                } else {
+                  const cat = categories.find((c) => c.id === slug);
+                  onCategorySelect?.(cat ?? { id: "todos" });
+                }
+              }}
+            />
+          ) : (
+            <CategoryBar
+              categories={categories}
+              activeId={selectedCategory}
+              onSelect={onCategorySelect}
+              variant="chip"
+              counts={counts}
+            />
+          )}
+        </div>
       </div>
       <div {...swipeHandlers}>
         {FEATURE_TABS


### PR DESCRIPTION
## Summary
- allow category bar and tabs to span edge-to-edge with bleed wrapper
- add edge spacing to chips for breathing room

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad3001828c8327b63098d9e87fcee4