### PR TITLE
refactor: centralize menu data

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,12 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 // Layout / UI
 import Header from "./components/Header";
 import Footer from "./components/Footer";
-import ProductLists, {
-  BREAKFAST_ITEMS,
-  MAINS_ITEMS,
-  DESSERT_BASE_ITEMS,
-  CATS,
-} from "./components/ProductLists";
+import ProductLists from "./components/ProductLists";
 import SearchBar from "./components/SearchBar";
 import HeroHeadline from "./components/HeroHeadline";
 import PromoBannerCarousel from "./components/PromoBannerCarousel";
@@ -21,11 +16,21 @@ import FloatingCartBar from "./components/FloatingCartBar";
 import CartDrawer from "./components/CartDrawer";
 import { useCart } from "./context/CartContext";
 import { banners as buildBanners } from "./data/banners";
-import { PREBOWL } from "./components/BowlsSection";
-import { smoothies, funcionales } from "./components/SmoothiesSection";
-import { COFFEES, INFUSIONS } from "./components/CoffeeSection";
-import { SODAS, OTHERS } from "./components/ColdDrinksSection";
-import { sandwichItems, sandwichPriceByItem } from "./components/Sandwiches";
+import {
+  cats,
+  breakfastItems,
+  mainDishes,
+  dessertBaseItems,
+  preBowl,
+  smoothies,
+  funcionales,
+  coffees,
+  infusions,
+  sodas,
+  otherDrinks,
+  sandwichItems,
+  sandwichPriceByItem,
+} from "./data/menuItems";
 import { getStockState, slugify } from "./utils/stock";
 
 // Póster QR
@@ -57,7 +62,7 @@ export default function App() {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const slug = params.get("cat");
-    const valid = ["todos", ...CATS];
+    const valid = ["todos", ...cats];
     if (slug && valid.includes(slug)) {
       handleCategorySelect(slug);
     }
@@ -65,16 +70,16 @@ export default function App() {
 
   const productMap = useMemo(() => {
     const collections = [
-      BREAKFAST_ITEMS,
-      MAINS_ITEMS,
-      DESSERT_BASE_ITEMS,
-      [PREBOWL],
+      breakfastItems,
+      mainDishes,
+      dessertBaseItems,
+      [preBowl],
       smoothies,
       funcionales,
-      COFFEES,
-      INFUSIONS,
-      SODAS,
-      OTHERS,
+      coffees,
+      infusions,
+      sodas,
+      otherDrinks,
     ];
     if (sandwichItems && sandwichPriceByItem) {
       const mapped = sandwichItems.map((it) => {
@@ -109,16 +114,16 @@ export default function App() {
     }
     return map;
   }, [
-    BREAKFAST_ITEMS,
-    MAINS_ITEMS,
-    DESSERT_BASE_ITEMS,
-    PREBOWL,
+    breakfastItems,
+    mainDishes,
+    dessertBaseItems,
+    preBowl,
     smoothies,
     funcionales,
-    COFFEES,
-    INFUSIONS,
-    SODAS,
-    OTHERS,
+    coffees,
+    infusions,
+    sodas,
+    otherDrinks,
     sandwichItems,
     sandwichPriceByItem,
   ]);
@@ -134,31 +139,31 @@ export default function App() {
         return st === "ok" || st === "low";
       }).length;
     const result = {
-      desayunos: count(BREAKFAST_ITEMS),
-      bowls: count([PREBOWL]),
-      platos: count(MAINS_ITEMS),
+      desayunos: count(breakfastItems),
+      bowls: count([preBowl]),
+      platos: count(mainDishes),
       sandwiches: count(
         sandwichItems?.map((it) => ({ id: "sandwich:" + it.key, name: it.name })) || []
       ),
       smoothies: count([...(smoothies || []), ...(funcionales || [])]),
-      cafe: count([...(COFFEES || []), ...(INFUSIONS || [])]),
-      bebidasfrias: count([...(SODAS || []), ...(OTHERS || [])]),
-      postres: count(DESSERT_BASE_ITEMS),
+      cafe: count([...(coffees || []), ...(infusions || [])]),
+      bebidasfrias: count([...(sodas || []), ...(otherDrinks || [])]),
+      postres: count(dessertBaseItems),
     };
     result.todos = Object.values(result).reduce((sum, n) => sum + n, 0);
     return result;
   }, [
-    BREAKFAST_ITEMS,
-    PREBOWL,
-    MAINS_ITEMS,
+    breakfastItems,
+    preBowl,
+    mainDishes,
     sandwichItems,
     smoothies,
     funcionales,
-    COFFEES,
-    INFUSIONS,
-    SODAS,
-    OTHERS,
-    DESSERT_BASE_ITEMS,
+    coffees,
+    infusions,
+    sodas,
+    otherDrinks,
+    dessertBaseItems,
   ]);
 
   function resolveProductById(id) {

--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -6,25 +6,10 @@ import { matchesQuery } from "../utils/strings";
 import { AddIconButton, StatusChip, PILL_XS, PILL_SM } from "./Buttons";
 const BowlBuilderModal = lazy(() => import("./BowlBuilderModal"));
 import { getStockState, slugify } from "../utils/stock";
+import { preBowl } from "../data/menuItems";
 
 // ← editar nombres y precios aquí
 const BASE_PRICE = Number(import.meta.env.VITE_BOWL_BASE_PRICE || 28000);
-
-// Poke Hawaiano (único prearmado)
-// ← editar nombres y precios aquí
-export const PREBOWL = {
-  id: "bowl-poke-hawaiano",
-  name: "Poke Hawaiano",
-  price: 32000, // 28.000 base + 4.000 premium salmón
-  desc: "Arroz blanco, salmón, aguacate, mango y pepino; ajonjolí y salsa mango-yaki.",
-  options: {
-    Base: "Arroz blanco",
-    Proteína: "Salmón",
-    Toppings: ["Aguacate", "Mango", "Pepino"],
-    Extras: ["Ajonjolí"],
-    Salsa: "Mango-yaki",
-  },
-};
 
 export default function BowlsSection({ query }) {
   const { addItem } = useCart();
@@ -32,19 +17,21 @@ export default function BowlsSection({ query }) {
 
   const openBuilder = () => setOpen(true);
 
+  if (!preBowl) return null;
+
   const addPre = () =>
     addItem({
-      productId: PREBOWL.id,
-      name: PREBOWL.name,
-      price: PREBOWL.price,
-      options: PREBOWL.options,
+      productId: preBowl.id,
+      name: preBowl.name,
+      price: preBowl.price,
+      options: preBowl.options,
     });
 
-  const st = getStockState(PREBOWL.id || slugify(PREBOWL.name));
+  const st = getStockState(preBowl.id || slugify(preBowl.name));
   const disabled = st === "out";
 
   const show = matchesQuery(
-    { title: PREBOWL.name, description: PREBOWL.desc },
+    { title: preBowl.name, description: preBowl.desc },
     query
   );
   if (query && !show) return null;
@@ -105,8 +92,8 @@ export default function BowlsSection({ query }) {
 
       {/* Card del prearmado */}
       <div className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12">
-        <p className="font-semibold">{PREBOWL.name}</p>
-        <p className="text-sm text-neutral-600">{PREBOWL.desc}</p>
+        <p className="font-semibold">{preBowl.name}</p>
+        <p className="text-sm text-neutral-600">{preBowl.desc}</p>
         <div className="mt-2 flex flex-wrap gap-2">
           {st === "low" && (
             <StatusChip variant="low">Pocas unidades</StatusChip>
@@ -114,11 +101,11 @@ export default function BowlsSection({ query }) {
           {st === "out" && <StatusChip variant="soldout">Agotado</StatusChip>}
         </div>
         <div className="absolute top-5 right-5 z-10 text-neutral-800 font-bold">
-          ${COP(PREBOWL.price)}
+          ${COP(preBowl.price)}
         </div>
         <AddIconButton
           className="absolute bottom-4 right-4 z-20"
-          aria-label={"Añadir " + PREBOWL.name}
+          aria-label={"Añadir " + preBowl.name}
           onClick={addPre}
           disabled={disabled}
         />

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -4,6 +4,7 @@ import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
 import { getStockState, slugify } from "../utils/stock";
 import { matchesQuery } from "../utils/strings";
+import { coffees, infusions } from "../data/menuItems";
 
 // ————————————————————————————————————————
 // Configuración de bebidas
@@ -13,98 +14,6 @@ const MILK_OPTIONS = [
   { id: "entera", label: "Entera", delta: 0 },
   { id: "deslactosada", label: "Deslactosada", delta: 0 },
   { id: "almendras", label: "Almendras (+$3.800)", delta: 3800 },
-];
-
-// Cafés (agrupados)
-// ← editar nombres y precios aquí
-export const COFFEES = [
-  // Sin leche por defecto
-  {
-    id: "cof-espresso",
-    name: "Espresso",
-    price: 4000,
-    desc: "Café concentrado, 30–40 ml. 100% espresso.",
-    milkPolicy: "optional",
-    kind: "espresso",
-  },
-  {
-    id: "cof-americano",
-    name: "Americano",
-    price: 4500,
-    desc: "Espresso diluido con agua caliente (~30% espresso, 70% agua).",
-    milkPolicy: "optional",
-    kind: "americano",
-  },
-  {
-    id: "cof-tinto",
-    name: "Tinto Campesino",
-    price: 4500,
-    desc: "Café filtrado tradicional.",
-    milkPolicy: "none",
-    kind: "tinto",
-  },
-
-  // Con leche por defecto
-  {
-    id: "cof-capuchino",
-    name: "Capuchino",
-    price: 6000,
-    desc: "Espresso con leche al vapor y espuma fina (~33% espresso, 33% leche, 33% espuma).",
-    milkPolicy: "required",
-    kind: "milk",
-  },
-  {
-    id: "cof-latte",
-    name: "Latte",
-    price: 6000,
-    desc: "Espresso con más leche y poca espuma (~20% espresso, 80% leche).",
-    milkPolicy: "required",
-    kind: "milk",
-  },
-  {
-    id: "cof-flat",
-    name: "Flat White",
-    price: 7000,
-    desc: "Doble espresso con leche microespumada (~40% espresso, 60% leche).",
-    milkPolicy: "required",
-    kind: "milk",
-  },
-  {
-    id: "cof-moca",
-    name: "Mocaccino",
-    price: 8000,
-    desc: "Espresso con cacao, leche y crema (~25% espresso, 65% leche, 10% cacao/crema).",
-    milkPolicy: "required",
-    kind: "milk",
-  },
-  {
-    id: "cof-choco",
-    name: "Chocolate Caliente",
-    price: 7000,
-    desc: "Bebida de cacao con leche.",
-    milkPolicy: "required",
-    kind: "milk",
-  },
-];
-
-// Infusiones y tés (incluye Chai)
-// ← editar nombres y precios aquí
-export const INFUSIONS = [
-  {
-    id: "aro-fresa",
-    name: "Aromatica de fresa",
-    price: 5000,
-    desc: "Té de frutos rojos con hierbabuena y fresas deshidratadas.",
-  },
-
-  // Chai especial: puede ser infusión o con leche (Chai Latte)
-  {
-    id: "inf-chai",
-    name: "Té Chai",
-    price: 9000,
-    desc: "Blend especiado. Puede ser infusión o con leche (Chai Latte).",
-    chai: true,
-  },
 ];
 
 // ————————————————————————————————————————
@@ -288,10 +197,10 @@ export default function CoffeeSection({ query }) {
   );
 
   // ————————————————————————————————————————
-  const coffeeItems = COFFEES.filter((item) =>
+  const coffeeItems = (coffees || []).filter((item) =>
     matchesQuery({ title: item.name, description: item.desc }, query)
   );
-  const infusionItems = INFUSIONS.filter((item) =>
+  const infusionItems = (infusions || []).filter((item) =>
     matchesQuery({ title: item.name, description: item.desc }, query)
   );
   if (!coffeeItems.length && !infusionItems.length) return null;

--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -5,61 +5,24 @@ import { AddIconButton, StatusChip } from "./Buttons";
 import { COP } from "../utils/money";
 import { getStockState, slugify } from "../utils/stock";
 import { matchesQuery } from "../utils/strings";
-
-// DATA EXACTA DE LA CARTA
-// ← editar nombres y precios aquí
-export const SODAS = [
-  { id: "soda-zen", name: "Soda Zen", price: 3500, desc: "Frutos rojos, Durazno, Limonata rosada" },
-  { id: "coca-250", name: "Coca-Cola 250 mL", price: 2500 },
-  { id: "coca-400", name: "Coca-Cola 400 mL", price: 4500 },
-  { id: "soda-manantial-400", name: "Soda Manantial 400 mL", price: 5000 },
-  { id: "agua-manantial-500", name: "Agua Manantial 500 mL", price: 6000 },
-  { id: "hatsu-rosas-frambuesa-lata", name: "Hatsu Rosas y Frambuesa (lata)", price: 4500 },
-  { id: "hatsu-uva-romero-lata", name: "Hatsu Uva y Romero (lata)", price: 4500 },
-  { id: "hatsu-uva-romero-botella", name: "Hatsu Uva y Romero (botella)", price: 4000 },
-  { id: "hatsu-albahaca-botella", name: "Hatsu Albahaca (botella)", price: 4000 },
-  { id: "hatsu-yerbabuena-botella", name: "Hatsu Yerbabuena (botella)", price: 4000 },
-];
-
-// ← editar nombres y precios aquí
-export const OTHERS = [
-  { id: "te-hatsu-400", name: "Té Hatsu 400 mL", price: 5000, desc: "Rojo, Negro, Aguamarina, Rosado, Fucsia, Blanco, Amarillo, Verde" },
-  { id: "te-hatsu-caja-200", name: "Té Hatsu Caja 200 mL", price: 2000, desc: "Blanco, Amarillo, Aguamarina" },
-  { id: "saviloe-250", name: "SaviLoe 250 mL", price: 3500 },
-  { id: "savifruit", name: "SaviFruit", price: 2500 },
-  { id: "electrolit", name: "Electrolit", price: 9000, desc: "Coco, Durazno, Fresa, Fresa-Kiwi, Lima-Limón, Naranja-Mandarina, Piña, Uva, Maracuyá, Mora azul" },
-  { id: "go-aloe-sparkling", name: "Go Aloe Sparkling", price: 6500, desc: "Watermelon, Natural, Ginger" },
-  { id: "cool-drink", name: "Cool Drink", price: 4000, desc: "Kiwi, Granada, Maracuyá, Manzana verde, Mangostino" },
-];
+import { sodas, otherDrinks } from "../data/menuItems";
 
 function Card({ item, onAdd }) {
   const st = getStockState(item.id || slugify(item.name));
   const disabled = st === "out";
   return (
     <div className="relative rounded-xl bg-white ring-1 ring-neutral-200 p-3 pr-16 pb-12 min-h-[96px]">
-      <p className="text-neutral-900 font-medium text-sm leading-tight break-words">
-        {item.name}
-      </p>
+      <p className="text-neutral-900 font-medium text-sm leading-tight break-words">{item.name}</p>
       {item.desc && (
-        <p className="mt-0.5 text-xs text-neutral-600 leading-snug break-words">
-          {item.desc}
-        </p>
+        <p className="mt-0.5 text-xs text-neutral-600 leading-snug break-words">{item.desc}</p>
       )}
       <div className="mt-2 flex flex-wrap gap-2">
-        {st === "low" && (
-          <StatusChip variant="low">Pocas unidades</StatusChip>
-        )}
-        {st === "out" && (
-          <StatusChip variant="soldout">Agotado</StatusChip>
-        )}
+        {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
+        {st === "out" && <StatusChip variant="soldout">Agotado</StatusChip>}
       </div>
-
-      {/* Precio fijo arriba-derecha con ancho mínimo para no chocar */}
       <div className="absolute top-2 right-2 min-w-[64px] text-right text-neutral-900 font-semibold text-sm">
         {"$" + COP(item.price)}
       </div>
-
-      {/* FAB compacto y claro de la zona de texto */}
       <AddIconButton
         className="absolute bottom-2 right-2 scale-90 sm:scale-100"
         aria-label={"Añadir " + item.name}
@@ -81,34 +44,34 @@ function Card({ item, onAdd }) {
 export default function ColdDrinksSection({ query }) {
   const { addItem } = useCart();
 
-  const sodas = SODAS.filter((it) =>
+  const sodasFiltered = (sodas || []).filter((it) =>
     matchesQuery({ title: it.name, description: it.desc }, query)
   );
-  const others = OTHERS.filter((it) =>
+  const othersFiltered = (otherDrinks || []).filter((it) =>
     matchesQuery({ title: it.name, description: it.desc }, query)
   );
-  if (!sodas.length && !others.length) return null;
+  if (!sodasFiltered.length && !othersFiltered.length) return null;
 
   return (
     <Section title="Bebidas frías">
-      {sodas.length > 0 && (
+      {sodasFiltered.length > 0 && (
         <>
           {/* Subgrupo: Gaseosas y Sodas */}
           <h3 className="text-sm font-semibold text-[#2f4131] mb-2">Gaseosas y Sodas</h3>
           <div className="grid grid-cols-2 gap-3">
-            {sodas.map((it) => (
+            {sodasFiltered.map((it) => (
               <Card key={it.id} item={it} onAdd={addItem} />
             ))}
           </div>
         </>
       )}
 
-      {others.length > 0 && (
+      {othersFiltered.length > 0 && (
         <>
           {/* Subgrupo: Jugos y otras bebidas frías */}
           <h3 className="mt-5 text-sm font-semibold text-[#2f4131] mb-2">Jugos y otras bebidas frías</h3>
           <div className="grid grid-cols-2 gap-3">
-            {others.map((it) => (
+            {othersFiltered.map((it) => (
               <Card key={it.id} item={it} onAdd={addItem} />
             ))}
           </div>

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -14,132 +14,15 @@ import CategoryHeader from "./CategoryHeader";
 import CategoryBar from "./CategoryBar";
 import CategoryTabs from "./CategoryTabs";
 import { categoryIcons } from "../data/categoryIcons";
+import {
+  cats,
+  breakfastItems,
+  mainDishes,
+  dessertBaseItems,
+} from "../data/menuItems";
 import useSwipeTabs from "../utils/useSwipeTabs";
 
 const FEATURE_TABS = import.meta.env.VITE_FEATURE_TABS === "1";
-
-export const CATS = [
-  "desayunos",
-  "bowls",
-  "platos",
-  "sandwiches",
-  "smoothies",
-  "cafe",
-  "bebidasfrias",
-];
-
-// Datos compartidos de los productos para búsqueda/identificación
-export const BREAKFAST_ITEMS = [
-  {
-    id: "des-sendero",
-    name: "Sendero Matinal",
-    price: 16000,
-    desc: "Bebida caliente + omelette con champiñones, lechugas, tomate cherry y queso, con tostadas multigranos. 🥚🌾🥛",
-  },
-  {
-    id: "des-cumbre",
-    name: "Cumbre Energética",
-    price: 18000,
-    desc: "Bebida caliente + arepa con queso mozzarella, aguacate y ajonjolí negro; yogur griego con arándanos y chía. 🥛🌾",
-  },
-  {
-    id: "des-huevos",
-    name: "Huevos al Gusto",
-    price: 17500,
-    desc: "3 huevos en sartén de hierro; 2 tostadas con queso crema y vegetales. 🥚🌾🥛",
-  },
-  {
-    id: "des-caldo",
-    name: "Caldo de Costilla de Res",
-    price: 18500,
-    desc: "Con papa y cilantro. Incluye bebida caliente + huevos al gusto, arepa y queso. 🥚🥛",
-  },
-  {
-    id: "des-amanecer",
-    name: "Bowl Amanecer Andino",
-    price: 19000,
-    desc: "Yogur griego + açaí, avena, coco, banano, fresa y arándanos; topping de chía o amapola. 🥛🌾🥜",
-  },
-];
-
-export const MAINS_ITEMS = [
-  {
-    id: "main-salmon",
-    name: "Salmón Andino 200 gr",
-    price: 47000,
-    desc: "En sartén de hierro, salsa miel-mostaza y orégano con guarnición de pure de ahuyama y ensalada de granos calientes.",
-  },
-  {
-    id: "main-trucha",
-    name: "Trucha del Páramo 450 gr",
-    price: 42000,
-    desc: "A la plancha con alioli griego con guarnición pure de papa y ensalada fría.",
-  },
-  {
-    id: "main-bolo",
-    name: "Spaghetti a la Boloñesa",
-    price: 28000,
-    desc: "Salsa pomodoro, carne de res; albahaca fresca y ralladura de parmesano. 🌾🥛",
-  },
-  {
-    id: "main-champi",
-    name: "Champiñones a la Madrileña",
-    price: 18000,
-    desc: "125 gr de champiñones en mantequilla y ajo, vino espumoso, jamón serrano, perejil y ralladura de parmesano. 🥛",
-  },
-  {
-    id: "main-ceviche",
-    name: "Ceviche de Camarón",
-    price: 22000,
-    desc: "Camarón marinado en cítricos; pimentón, salsa de tomate casera, cilantro y cebolla morada; con aguacate.",
-  },
-  {
-    id: "main-burger",
-    name: "Burger Andina (Pavo 150 gr)",
-    price: 26000,
-    desc: "Pavo sazonado, salsa de yogur, tomate, lechuga, chucrut y queso Colby Jack en pan artesanal. 🥛🌾",
-  },
-];
-
-export const DESSERT_BASE_ITEMS = [
-  {
-    id: "post-red",
-    name: "Red Velvet",
-    price: 11000,
-    desc: "Bizcocho rojo con crema batida de la casa, endulzado con eritritol y stevia. 🌾🥛",
-  },
-  {
-    id: "post-tres",
-    name: "Tres Leches (saludable)",
-    price: 6200,
-    desc: "Harina de almendras y avena; dulce de tres leches con alulosa; chantilly con eritritol. 🥛🌾",
-  },
-  {
-    id: "post-tira",
-    name: "Tiramisú (saludable)",
-    price: 6800,
-    desc: "Bizcocho de almendras y avena, café especial, chantilly con alulosa y cacao espolvoreado. 🥛🌾",
-  },
-  {
-    id: "post-amap",
-    name: "Torta de Amapola",
-    price: 10000,
-    desc: "Harina de avena y semillas de amapola; crema chantilly endulzada con alulosa. 🥛🌾",
-  },
-  {
-    id: "post-vasca",
-    name: "Torta Vasca de Limón",
-    price: 10000,
-    desc: "Crema de leche, queso crema y maicena; vainilla y sal marina. 🥛",
-  },
-  {
-    id: "post-fresas",
-    name: "Fresas con Crema",
-    price: 9000,
-    desc: "Fresas con crema chantilly endulzada con alulosa. 🥛",
-  },
-];
-
 export default function ProductLists({
   query,
   selectedCategory,
@@ -263,13 +146,13 @@ export default function ProductLists({
 
   useEffect(() => {
     if (!FEATURE_TABS) return;
-    const valid = ["todos", ...CATS];
+    const valid = ["todos", ...(cats || [])];
     if (!selectedCategory || !valid.includes(selectedCategory)) {
       onCategorySelect?.({ id: "todos" });
     }
   }, [selectedCategory, onCategorySelect]);
 
-  const orderedTabs = ["todos", ...CATS];
+  const orderedTabs = ["todos", ...(cats || [])];
   const swipeHandlers = useSwipeTabs({
     onPrev: () => {
       const idx = orderedTabs.indexOf(selectedCategory);
@@ -341,7 +224,7 @@ export default function ProductLists({
 }
 
 export function Breakfasts({ query }) {
-  const items = BREAKFAST_ITEMS.filter((it) =>
+  const items = (breakfastItems || []).filter((it) =>
     matchesQuery({ title: it.name, description: it.desc }, query)
   );
   if (!items.length) return null;
@@ -349,7 +232,7 @@ export function Breakfasts({ query }) {
 }
 
 export function Mains({ query }) {
-  const items = MAINS_ITEMS.filter((it) =>
+  const items = (mainDishes || []).filter((it) =>
     matchesQuery({ title: it.name, description: it.desc }, query)
   );
   if (!items.length) return null;
@@ -377,7 +260,7 @@ export function Desserts({ query }) {
   const filteredCumbre = cumbreSabores.filter((s) =>
     matchesQuery({ title: s.label }, query)
   );
-  const base = DESSERT_BASE_ITEMS.filter((p) =>
+  const base = (dessertBaseItems || []).filter((p) =>
     matchesQuery({ title: p.name, description: p.desc }, query)
   );
 

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -4,42 +4,10 @@ import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 import { getStockState, slugify } from "../utils/stock";
 import { matchesQuery } from "../utils/strings";
-
-export const sandwichPriceByItem = {
-  cerdo: { clasico: 12000, grande: 32000 },
-  pollo: { clasico: 14000, grande: 35000 },
-  pavo: { clasico: 19000, grande: 39000 },
-  serrano: { unico: 12500 },
-  cosecha: { unico: 16000 },
-};
-
-export const sandwichItems = [
-  {
-    key: "cerdo",
-    name: "Sandwich de Cerdo",
-    desc: "Pierna de cerdo horneada con Mayo-Pesto, lechuga, tomate y suero costeño.",
-  },
-  {
-    key: "pollo",
-    name: "Sandwich de Pollo",
-    desc: "Pechuga en cocción lenta, alioli de yogurt (con ajo), lechuga y tomate.",
-  },
-  {
-    key: "pavo",
-    name: "Sandwich de Pavo",
-    desc: "Pavo horneado en cocción lenta, alioli de yogurt (con ajo), tomates secos y lechuga.",
-  },
-  {
-    key: "serrano",
-    name: "Serrano Di Búfala",
-    desc: "Queso crema, espinaca, jamón serrano, queso de búfala, tomate cherry salteado y balsámico. 🥛",
-  },
-  {
-    key: "cosecha",
-    name: "Cosecha del Páramo 🌿",
-    desc: "Hummus casero, pimientos asados, aguacate, champiñón a la plancha, pepino y lechugas; lámina de queso costeño frito. 🥛",
-  },
-];
+import {
+  sandwichItems,
+  sandwichPriceByItem,
+} from "../data/menuItems";
 
 export default function Sandwiches({ query }) {
   const cart = useCart();
@@ -51,8 +19,8 @@ export default function Sandwiches({ query }) {
     { id: "grande", label: "Grande (300 g de proteína)" },
   ];
 
-  const priceByItem = sandwichPriceByItem;
-  const items = sandwichItems;
+  const priceByItem = sandwichPriceByItem || {};
+  const items = sandwichItems || [];
   const filtered = items.filter((it) =>
     matchesQuery({ title: it.name, description: it.desc }, query)
   );

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -3,50 +3,7 @@ import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 import { getStockState, slugify } from "../utils/stock";
 import { matchesQuery } from "../utils/strings";
-
-// ← editar nombres y precios aquí
-export const smoothies = [
-  {
-    id: "smoothie:Brisas Tropicales",
-    name: "Brisas Tropicales",
-    price: 18000,
-    desc: "Hierbabuena, mango, maracuyá y piña; leche de almendras, yogur griego y chía. 🥛🥜",
-  },
-  {
-    id: "smoothie:El Néctar Andino",
-    name: "El Néctar Andino",
-    price: 17000,
-    desc: "Fresas y arándanos, marañones y avena; leche a elección y vainilla. 🥛🌾🥜",
-  },
-  {
-    id: "smoothie:Verde Amanecer de la Sabana",
-    name: "Verde Amanecer de la Sabana",
-    price: 16000,
-    desc: "Espinaca, kiwi, banano, manzana verde, jengibre y yerbabuena.",
-  },
-];
-
-// ← editar nombres y precios aquí
-export const funcionales = [
-  {
-    id: "smoothie:Elixir del Cóndor (Detox)",
-    name: "Elixir del Cóndor (Detox)",
-    price: 18000,
-    desc: "Pepino, apio, manzana verde, limón y jengibre; espirulina + clorofila.",
-  },
-  {
-    id: "smoothie:Guardian de la Montaña",
-    name: "Guardián de la Montaña",
-    price: 17000,
-    desc: "Naranja, cúrcuma, zanahoria, un toque de pimienta negra, jengibre y miel de abejas local.",
-  },
-  {
-    id: "smoothie:Aurora Proteica",
-    name: "Aurora Proteica",
-    price: 22000,
-    desc: "Leche de almendras, proteína vegetal (vainilla/chocolate), banano y chía. 🥜",
-  },
-];
+import { smoothies, funcionales } from "../data/menuItems";
 
 function List({ items, onAdd }) {
   return (
@@ -94,10 +51,10 @@ export default function SmoothiesSection({ query }) {
       price: p.price,
     });
 
-  const smoothiesFiltered = smoothies.filter((p) =>
+  const smoothiesFiltered = (smoothies || []).filter((p) =>
     matchesQuery({ title: p.name, description: p.desc }, query)
   );
-  const funcionalesFiltered = funcionales.filter((p) =>
+  const funcionalesFiltered = (funcionales || []).filter((p) =>
     matchesQuery({ title: p.name, description: p.desc }, query)
   );
 

--- a/src/data/menuItems.js
+++ b/src/data/menuItems.js
@@ -1,0 +1,321 @@
+export const cats = [
+  "desayunos",
+  "bowls",
+  "platos",
+  "sandwiches",
+  "smoothies",
+  "cafe",
+  "bebidasfrias",
+];
+
+export const breakfastItems = [
+  {
+    id: "des-sendero",
+    name: "Sendero Matinal",
+    price: 16000,
+    desc: "Bebida caliente + omelette con champiñones, lechugas, tomate cherry y queso, con tostadas multigranos. 🥚🌾🥛",
+  },
+  {
+    id: "des-cumbre",
+    name: "Cumbre Energética",
+    price: 18000,
+    desc: "Bebida caliente + arepa con queso mozzarella, aguacate y ajonjolí negro; yogur griego con arándanos y chía. 🥛🌾",
+  },
+  {
+    id: "des-huevos",
+    name: "Huevos al Gusto",
+    price: 17500,
+    desc: "3 huevos en sartén de hierro; 2 tostadas con queso crema y vegetales. 🥚🌾🥛",
+  },
+  {
+    id: "des-caldo",
+    name: "Caldo de Costilla de Res",
+    price: 18500,
+    desc: "Con papa y cilantro. Incluye bebida caliente + huevos al gusto, arepa y queso. 🥚🥛",
+  },
+  {
+    id: "des-amanecer",
+    name: "Bowl Amanecer Andino",
+    price: 19000,
+    desc: "Yogur griego + açaí, avena, coco, banano, fresa y arándanos; topping de chía o amapola. 🥛🌾🥜",
+  },
+];
+
+export const mainDishes = [
+  {
+    id: "main-salmon",
+    name: "Salmón Andino 200 gr",
+    price: 47000,
+    desc: "En sartén de hierro, salsa miel-mostaza y orégano con guarnición de pure de ahuyama y ensalada de granos calientes.",
+  },
+  {
+    id: "main-trucha",
+    name: "Trucha del Páramo 450 gr",
+    price: 42000,
+    desc: "A la plancha con alioli griego con guarnición pure de papa y ensalada fría.",
+  },
+  {
+    id: "main-bolo",
+    name: "Spaghetti a la Boloñesa",
+    price: 28000,
+    desc: "Salsa pomodoro, carne de res; albahaca fresca y ralladura de parmesano. 🌾🥛",
+  },
+  {
+    id: "main-champi",
+    name: "Champiñones a la Madrileña",
+    price: 18000,
+    desc: "125 gr de champiñones en mantequilla y ajo, vino espumoso, jamón serrano, perejil y ralladura de parmesano. 🥛",
+  },
+  {
+    id: "main-ceviche",
+    name: "Ceviche de Camarón",
+    price: 22000,
+    desc: "Camarón marinado en cítricos; pimentón, salsa de tomate casera, cilantro y cebolla morada; con aguacate.",
+  },
+  {
+    id: "main-burger",
+    name: "Burger Andina (Pavo 150 gr)",
+    price: 26000,
+    desc: "Pavo sazonado, salsa de yogur, tomate, lechuga, chucrut y queso Colby Jack en pan artesanal. 🥛🌾",
+  },
+];
+
+export const dessertBaseItems = [
+  {
+    id: "post-red",
+    name: "Red Velvet",
+    price: 11000,
+    desc: "Bizcocho rojo con crema batida de la casa, endulzado con eritritol y stevia. 🌾🥛",
+  },
+  {
+    id: "post-tres",
+    name: "Tres Leches (saludable)",
+    price: 6200,
+    desc: "Harina de almendras y avena; dulce de tres leches con alulosa; chantilly con eritritol. 🥛🌾",
+  },
+  {
+    id: "post-tira",
+    name: "Tiramisú (saludable)",
+    price: 6800,
+    desc: "Bizcocho de almendras y avena, café especial, chantilly con alulosa y cacao espolvoreado. 🥛🌾",
+  },
+  {
+    id: "post-amap",
+    name: "Torta de Amapola",
+    price: 10000,
+    desc: "Harina de avena y semillas de amapola; crema chantilly endulzada con alulosa. 🥛🌾",
+  },
+  {
+    id: "post-vasca",
+    name: "Torta Vasca de Limón",
+    price: 10000,
+    desc: "Crema de leche, queso crema y maicena; vainilla y sal marina. 🥛",
+  },
+  {
+    id: "post-fresas",
+    name: "Fresas con Crema",
+    price: 9000,
+    desc: "Fresas con crema chantilly endulzada con alulosa. 🥛",
+  },
+];
+
+export const preBowl = {
+  id: "bowl-poke-hawaiano",
+  name: "Poke Hawaiano",
+  price: 32000, // 28.000 base + 4.000 premium salmón
+  desc: "Arroz blanco, salmón, aguacate, mango y pepino; ajonjolí y salsa mango-yaki.",
+  options: {
+    Base: "Arroz blanco",
+    Proteína: "Salmón",
+    Toppings: ["Aguacate", "Mango", "Pepino"],
+    Extras: ["Ajonjolí"],
+    Salsa: "Mango-yaki",
+  },
+};
+
+export const sandwichPriceByItem = {
+  cerdo: { clasico: 12000, grande: 32000 },
+  pollo: { clasico: 14000, grande: 35000 },
+  pavo: { clasico: 19000, grande: 39000 },
+  serrano: { unico: 12500 },
+  cosecha: { unico: 16000 },
+};
+
+export const sandwichItems = [
+  {
+    key: "cerdo",
+    name: "Sandwich de Cerdo",
+    desc: "Pierna de cerdo horneada con Mayo-Pesto, lechuga, tomate y suero costeño.",
+  },
+  {
+    key: "pollo",
+    name: "Sandwich de Pollo",
+    desc: "Pechuga en cocción lenta, alioli de yogurt (con ajo), lechuga y tomate.",
+  },
+  {
+    key: "pavo",
+    name: "Sandwich de Pavo",
+    desc: "Pavo horneado en cocción lenta, alioli de yogurt (con ajo), tomates secos y lechuga.",
+  },
+  {
+    key: "serrano",
+    name: "Serrano Di Búfala",
+    desc: "Queso crema, espinaca, jamón serrano, queso de búfala, tomate cherry salteado y balsámico. 🥛",
+  },
+  {
+    key: "cosecha",
+    name: "Cosecha del Páramo 🌿",
+    desc: "Hummus casero, pimientos asados, aguacate, champiñón a la plancha, pepino y lechugas; lámina de queso costeño frito. 🥛",
+  },
+];
+
+export const smoothies = [
+  {
+    id: "smoothie:Brisas Tropicales",
+    name: "Brisas Tropicales",
+    price: 18000,
+    desc: "Hierbabuena, mango, maracuyá y piña; leche de almendras, yogur griego y chía. 🥛🥜",
+  },
+  {
+    id: "smoothie:El Néctar Andino",
+    name: "El Néctar Andino",
+    price: 17000,
+    desc: "Fresas y arándanos, marañones y avena; leche a elección y vainilla. 🥛🌾🥜",
+  },
+  {
+    id: "smoothie:Verde Amanecer de la Sabana",
+    name: "Verde Amanecer de la Sabana",
+    price: 16000,
+    desc: "Espinaca, kiwi, banano, manzana verde, jengibre y yerbabuena.",
+  },
+];
+
+export const funcionales = [
+  {
+    id: "smoothie:Elixir del Cóndor (Detox)",
+    name: "Elixir del Cóndor (Detox)",
+    price: 18000,
+    desc: "Pepino, apio, manzana verde, limón y jengibre; espirulina + clorofila.",
+  },
+  {
+    id: "smoothie:Guardian de la Montaña",
+    name: "Guardián de la Montaña",
+    price: 17000,
+    desc: "Naranja, cúrcuma, zanahoria, un toque de pimienta negra, jengibre y miel de abejas local.",
+  },
+  {
+    id: "smoothie:Aurora Proteica",
+    name: "Aurora Proteica",
+    price: 22000,
+    desc: "Leche de almendras, proteína vegetal (vainilla/chocolate), banano y chía. 🥜",
+  },
+];
+
+export const coffees = [
+  // Sin leche por defecto
+  {
+    id: "cof-espresso",
+    name: "Espresso",
+    price: 4000,
+    desc: "Café concentrado, 30–40 ml. 100% espresso.",
+    milkPolicy: "optional",
+    kind: "espresso",
+  },
+  {
+    id: "cof-americano",
+    name: "Americano",
+    price: 4500,
+    desc: "Espresso diluido con agua caliente (~30% espresso, 70% agua).",
+    milkPolicy: "optional",
+    kind: "americano",
+  },
+  {
+    id: "cof-tinto",
+    name: "Tinto Campesino",
+    price: 4500,
+    desc: "Café filtrado tradicional.",
+    milkPolicy: "none",
+    kind: "tinto",
+  },
+  // Con leche por defecto
+  {
+    id: "cof-capuchino",
+    name: "Capuchino",
+    price: 6000,
+    desc: "Espresso con leche al vapor y espuma fina (~33% espresso, 33% leche, 33% espuma).",
+    milkPolicy: "required",
+    kind: "milk",
+  },
+  {
+    id: "cof-latte",
+    name: "Latte",
+    price: 6000,
+    desc: "Espresso con más leche y poca espuma (~20% espresso, 80% leche).",
+    milkPolicy: "required",
+    kind: "milk",
+  },
+  {
+    id: "cof-flat",
+    name: "Flat White",
+    price: 7000,
+    desc: "Doble espresso con leche microespumada (~40% espresso, 60% leche).",
+    milkPolicy: "required",
+    kind: "milk",
+  },
+  {
+    id: "cof-moca",
+    name: "Mocaccino",
+    price: 8000,
+    desc: "Espresso con cacao, leche y crema (~25% espresso, 65% leche, 10% cacao/crema).",
+    milkPolicy: "required",
+    kind: "milk",
+  },
+  {
+    id: "cof-choco",
+    name: "Chocolate Caliente",
+    price: 7000,
+    desc: "Bebida de cacao con leche.",
+    milkPolicy: "required",
+    kind: "milk",
+  },
+];
+
+export const infusions = [
+  {
+    id: "aro-fresa",
+    name: "Aromatica de fresa",
+    price: 5000,
+    desc: "Té de frutos rojos con hierbabuena y fresas deshidratadas.",
+  },
+  {
+    id: "inf-chai",
+    name: "Té Chai",
+    price: 9000,
+    desc: "Blend especiado. Puede ser infusión o con leche (Chai Latte).",
+    chai: true,
+  },
+];
+
+export const sodas = [
+  { id: "soda-zen", name: "Soda Zen", price: 3500, desc: "Frutos rojos, Durazno, Limonata rosada" },
+  { id: "coca-250", name: "Coca-Cola 250 mL", price: 2500 },
+  { id: "coca-400", name: "Coca-Cola 400 mL", price: 4500 },
+  { id: "soda-manantial-400", name: "Soda Manantial 400 mL", price: 5000 },
+  { id: "agua-manantial-500", name: "Agua Manantial 500 mL", price: 6000 },
+  { id: "hatsu-rosas-frambuesa-lata", name: "Hatsu Rosas y Frambuesa (lata)", price: 4500 },
+  { id: "hatsu-uva-romero-lata", name: "Hatsu Uva y Romero (lata)", price: 4500 },
+  { id: "hatsu-uva-romero-botella", name: "Hatsu Uva y Romero (botella)", price: 4000 },
+  { id: "hatsu-albahaca-botella", name: "Hatsu Albahaca (botella)", price: 4000 },
+  { id: "hatsu-yerbabuena-botella", name: "Hatsu Yerbabuena (botella)", price: 4000 },
+];
+
+export const otherDrinks = [
+  { id: "te-hatsu-400", name: "Té Hatsu 400 mL", price: 5000, desc: "Rojo, Negro, Aguamarina, Rosado, Fucsia, Blanco, Amarillo, Verde" },
+  { id: "te-hatsu-caja-200", name: "Té Hatsu Caja 200 mL", price: 2000, desc: "Blanco, Amarillo, Aguamarina" },
+  { id: "saviloe-250", name: "SaviLoe 250 mL", price: 3500 },
+  { id: "savifruit", name: "SaviFruit", price: 2500 },
+  { id: "electrolit", name: "Electrolit", price: 9000, desc: "Coco, Durazno, Fresa, Fresa-Kiwi, Lima-Limón, Naranja-Mandarina, Piña, Uva, Maracuyá, Mora azul" },
+  { id: "go-aloe-sparkling", name: "Go Aloe Sparkling", price: 6500, desc: "Watermelon, Natural, Ginger" },
+  { id: "cool-drink", name: "Cool Drink", price: 4000, desc: "Kiwi, Granada, Maracuyá, Manzana verde, Mangostino" },
+];
+


### PR DESCRIPTION
## Summary
- move all menu item data into `src/data/menuItems.js`
- rename data exports to camelCase and update all components to import from the new module
- keep `ProductLists.jsx` focused on rendering components only

## Testing
- `npm run dev`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad30e32ef48327ad321ff72876472c