### PR TITLE
feat: toggle category tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,9 @@ import { getStockState, slugify } from "./utils/stock";
 import QrPoster from "./components/QrPoster";
 import Toast from "./components/Toast";
 
+const FEATURE_TABS = import.meta.env.VITE_FEATURE_TABS === "1";
+const VALID_CATEGORIES = ["todos", ...CATS];
+
 export default function App() {
   const [open, setOpen] = useState(false);
   const [openGuide, setOpenGuide] = useState(false);
@@ -57,11 +60,16 @@ export default function App() {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const slug = params.get("cat");
-    const valid = ["todos", ...CATS];
-    if (slug && valid.includes(slug)) {
+    if (slug && VALID_CATEGORIES.includes(slug)) {
       handleCategorySelect(slug);
     }
   }, []);
+
+  useEffect(() => {
+    if (!VALID_CATEGORIES.includes(selectedCategory)) {
+      setSelectedCategory("todos");
+    }
+  }, [selectedCategory]);
 
   const productMap = useMemo(() => {
     const collections = [
@@ -193,6 +201,7 @@ export default function App() {
           selectedCategory={selectedCategory}
           onCategorySelect={handleCategorySelect}
           counts={counts}
+          featureTabs={FEATURE_TABS}
         />
 
         <Footer />

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
 import { getStockState, slugify } from "../utils/stock";
@@ -15,8 +15,6 @@ import CategoryBar from "./CategoryBar";
 import CategoryTabs from "./CategoryTabs";
 import { categoryIcons } from "../data/categoryIcons";
 import useSwipeTabs from "../utils/useSwipeTabs";
-
-const FEATURE_TABS = import.meta.env.VITE_FEATURE_TABS === "1";
 
 export const CATS = [
   "desayunos",
@@ -145,6 +143,7 @@ export default function ProductLists({
   selectedCategory,
   onCategorySelect,
   counts = {},
+  featureTabs = false,
 }) {
   const categories = useMemo(
     () => [
@@ -261,14 +260,6 @@ export default function ProductLists({
     </div>
   );
 
-  useEffect(() => {
-    if (!FEATURE_TABS) return;
-    const valid = ["todos", ...CATS];
-    if (!selectedCategory || !valid.includes(selectedCategory)) {
-      onCategorySelect?.({ id: "todos" });
-    }
-  }, [selectedCategory, onCategorySelect]);
-
   const orderedTabs = ["todos", ...CATS];
   const swipeHandlers = useSwipeTabs({
     onPrev: () => {
@@ -302,7 +293,7 @@ export default function ProductLists({
       <div className="mx-auto max-w-screen-md px-4 md:px-6">
         <CategoryHeader />
         <div className="-mx-4 md:-mx-6 px-4 md:px-6">
-          {FEATURE_TABS ? (
+          {featureTabs ? (
             <CategoryTabs
               items={tabItems}
               value={selectedCategory}
@@ -328,7 +319,7 @@ export default function ProductLists({
         </div>
       </div>
       <div {...swipeHandlers}>
-        {FEATURE_TABS
+        {featureTabs
           ? selectedCategory === "todos"
             ? sections.map(renderPanel)
             : sections


### PR DESCRIPTION
## Summary
- add FEATURE_TABS flag and category validation on home page
- wire ProductLists to render a single category when tabs are enabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad329eea6c83278ae8ef3eded2d335