### PR TITLE
Sync category tab with URL query param

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,26 +50,26 @@ export default function App() {
 
   function handleCategorySelect(cat) {
     const slug = typeof cat === "string" ? cat : cat.id;
-    const url = new URL(window.location.href);
-    url.searchParams.set("cat", slug);
-    window.history.replaceState(null, "", url);
     setSelectedCategory(slug);
-    if (slug !== "todos") {
-      const panelId = `panel-${slug}`;
-      requestAnimationFrame(() => {
-        document.getElementById(panelId)?.focus();
-      });
-    }
   }
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const slug = params.get("cat");
-    if (slug && VALID_CATEGORIES.includes(slug)) {
-
-      handleCategorySelect(slug);
-    }
+    const cat = params.get("cat");
+    if (cat && VALID_CATEGORIES.includes(cat)) setSelectedCategory(cat);
   }, []);
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    url.searchParams.set("cat", selectedCategory);
+    window.history.replaceState(null, "", url);
+    if (selectedCategory !== "todos") {
+      const panelId = `panel-${selectedCategory}`;
+      requestAnimationFrame(() => {
+        document.getElementById(panelId)?.focus();
+      });
+    }
+  }, [selectedCategory]);
 
   useEffect(() => {
     if (!VALID_CATEGORIES.includes(selectedCategory)) {


### PR DESCRIPTION
## Summary
- read `cat` query parameter on load and update selected category
- keep URL `cat` parameter in sync when switching tabs
- focus visible tab panel after tab change for accessibility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad33e092688327b9bf37caaaab7557