### PR TITLE
feat: show category count in header

### DIFF
--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -1,4 +1,25 @@
-export default function CategoryHeader() {
+function labelDe(slug) {
+  const labels = {
+    todos: "Todos",
+    desayunos: "Desayunos",
+    bowls: "Bowls",
+    platos: "Platos Fuertes",
+    sandwiches: "Sándwiches",
+    smoothies: "Smoothies & Funcionales",
+    cafe: "Café de especialidad",
+    bebidasfrias: "Bebidas frías",
+    postres: "Postres",
+  };
+  return labels[slug] || "";
+}
+
+export default function CategoryHeader({
+  selectedCategory = "todos",
+  visibleCount = 0,
+  featureTabs = false,
+}) {
+  const label = labelDe(selectedCategory);
+  const showHint = selectedCategory === "todos";
   return (
     <section
       aria-labelledby="cat-title"
@@ -8,11 +29,18 @@ export default function CategoryHeader() {
         id="cat-title"
         className="text-lg md:text-xl font-semibold tracking-tight text-[#2f4131]"
       >
-        Explora por categoría
+        {label}
+        {featureTabs && selectedCategory !== "todos" && (
+          <span className="ml-2 text-sm text-zinc-500 font-medium align-middle">
+            ({visibleCount})
+          </span>
+        )}
       </h2>
-      <p className="text-sm md:text-[15px] text-zinc-600">
-        Elige una categoría o desliza para ver más →
-      </p>
+      {showHint && (
+        <p className="text-sm md:text-[15px] text-zinc-600">
+          Elige una categoría o desliza para ver más →
+        </p>
+      )}
     </section>
   );
 }

--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -18,7 +18,7 @@ function IconWithFallback({ icon, size = 32, className }) {
   );
 }
 
-export default function CategoryTabs({ value, onChange, items = [], counts = {} }) {
+export default function CategoryTabs({ value, onChange, items = [] }) {
   const tabRefs = useRef([]);
   const baseItemClasses =
     "flex-none w-[100px] basis-[100px] h-[110px] snap-start rounded-xl bg-white/60 backdrop-blur-sm transition-colors transition-shadow duration-150 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,.3)] focus:ring-offset-2";
@@ -108,11 +108,6 @@ export default function CategoryTabs({ value, onChange, items = [], counts = {} 
                   >
                     {item.label}
                   </span>
-                  {counts[item.id] != null && (
-                    <span className="min-w-[22px] h-[22px] text-[12px] rounded-full bg-[#2f4131] text-white grid place-items-center ml-1">
-                      {counts[item.id]}
-                    </span>
-                  )}
                 </span>
               </span>
             </button>

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -152,6 +152,7 @@ export default function ProductLists({
   counts = {},
   featureTabs = false,
 }) {
+  const visibleCount = counts[selectedCategory] ?? 0;
   const categories = useMemo(
     () => [
       { id: "desayunos", label: "Desayunos" },
@@ -299,13 +300,16 @@ export default function ProductLists({
   return (
     <>
       <div className="mx-auto max-w-screen-md px-4 md:px-6">
-        <CategoryHeader />
+        <CategoryHeader
+          selectedCategory={selectedCategory}
+          visibleCount={visibleCount}
+          featureTabs={featureTabs}
+        />
         <div className="-mx-4 md:-mx-6 px-4 md:px-6">
           {featureTabs ? (
             <CategoryTabs
               items={tabItems}
               value={selectedCategory}
-              counts={counts}
               onChange={(slug) => {
                 if (slug === "todos") {
                   onCategorySelect?.({ id: "todos" });


### PR DESCRIPTION
## Summary
- replace category header with dynamic label and count
- drop badge counts from category tabs
- plumb visible product counts into category header

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad34c83d7883278a0f012caf793312