### PR TITLE
refactor: alias menu categories

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import CartDrawer from "./components/CartDrawer";
 import { useCart } from "./context/CartContext";
 import { banners as buildBanners } from "./data/banners";
 import {
+  cats as CATS,
   breakfastItems,
   mainDishes,
   dessertBaseItems,
@@ -37,7 +38,7 @@ import QrPoster from "./components/QrPoster";
 import Toast from "./components/Toast";
 
 const FEATURE_TABS = import.meta.env.VITE_FEATURE_TABS === "1";
-const VALID_CATEGORIES = ["todos", ...cats];
+const VALID_CATEGORIES = ["todos", ...CATS];
 
 
 export default function App() {
@@ -56,7 +57,7 @@ export default function App() {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const cat = params.get("cat");
-    if (cat && CATS.includes(cat)) setSelectedCategory(cat);
+    if (cat && VALID_CATEGORIES.includes(cat)) setSelectedCategory(cat);
   }, []);
 
   useEffect(() => {
@@ -72,7 +73,7 @@ export default function App() {
   }, [selectedCategory]);
 
   useEffect(() => {
-    if (!CATS.includes(selectedCategory)) {
+    if (!VALID_CATEGORIES.includes(selectedCategory)) {
       setSelectedCategory("todos");
     }
   }, [selectedCategory]);


### PR DESCRIPTION
## Summary
- alias menu `cats` as `CATS` for clarity
- consolidate valid categories and update validation checks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad39c1cc2c8327b3850b5ca4dbcb26