### PR TITLE
feat: show section counts and simplify category bar

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -25,7 +25,6 @@ export default function CategoryBar({
   activeId,
   onSelect,
   variant = "chip",
-  counts = {},
 }) {
   const baseItemClasses =
     variant === "chip"
@@ -100,11 +99,6 @@ export default function CategoryBar({
                     >
                       {cat.label}
                     </span>
-                    {counts[cat.id] != null && (
-                      <span className="min-w-[22px] h-[22px] text-[12px] rounded-full bg-[#2f4131] text-white grid place-items-center ml-1">
-                        {counts[cat.id]}
-                      </span>
-                    )}
                   </span>
                 </span>
               </button>

--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -16,7 +16,6 @@ function labelDe(slug) {
 export default function CategoryHeader({
   selectedCategory = "todos",
   visibleCount = 0,
-  featureTabs = false,
 }) {
   const label = labelDe(selectedCategory);
   const showHint = selectedCategory === "todos";
@@ -30,7 +29,7 @@ export default function CategoryHeader({
         className="text-lg md:text-xl font-semibold tracking-tight text-[#2f4131]"
       >
         {label}
-        {featureTabs && selectedCategory !== "todos" && (
+        {selectedCategory !== "todos" && (
           <span className="ml-2 text-sm text-zinc-500 font-medium align-middle">
             ({visibleCount})
           </span>

--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -41,7 +41,7 @@ function Card({ item, onAdd }) {
   );
 }
 
-export default function ColdDrinksSection({ query }) {
+export default function ColdDrinksSection({ query, count }) {
   const { addItem } = useCart();
 
   const sodasFiltered = (sodas || []).filter((it) =>
@@ -53,7 +53,7 @@ export default function ColdDrinksSection({ query }) {
   if (!sodasFiltered.length && !othersFiltered.length) return null;
 
   return (
-    <Section title="Bebidas frías">
+    <Section title="Bebidas frías" count={count}>
       {sodasFiltered.length > 0 && (
         <>
           {/* Subgrupo: Gaseosas y Sodas */}

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -76,7 +76,7 @@ export default function ProductLists({
       {
         id: "desayunos",
         element: (
-          <Section title="Desayunos">
+          <Section title="Desayunos" count={counts.desayunos}>
             <Breakfasts query={query} />
           </Section>
         ),
@@ -84,7 +84,7 @@ export default function ProductLists({
       {
         id: "bowls",
         element: (
-          <Section title="Bowls">
+          <Section title="Bowls" count={counts.bowls}>
             <BowlsSection query={query} />
           </Section>
         ),
@@ -92,7 +92,7 @@ export default function ProductLists({
       {
         id: "platos",
         element: (
-          <Section title="Platos Fuertes">
+          <Section title="Platos Fuertes" count={counts.platos}>
             <Mains query={query} />
           </Section>
         ),
@@ -100,7 +100,7 @@ export default function ProductLists({
       {
         id: "sandwiches",
         element: (
-          <Section title="Sándwiches">
+          <Section title="Sándwiches" count={counts.sandwiches}>
             <Sandwiches query={query} />
           </Section>
         ),
@@ -108,7 +108,7 @@ export default function ProductLists({
       {
         id: "smoothies",
         element: (
-          <Section title="Smoothies & Funcionales">
+          <Section title="Smoothies & Funcionales" count={counts.smoothies}>
             <SmoothiesSection query={query} />
           </Section>
         ),
@@ -116,22 +116,27 @@ export default function ProductLists({
       {
         id: "cafe",
         element: (
-          <Section title="Café de especialidad">
+          <Section title="Café de especialidad" count={counts.cafe}>
             <CoffeeSection query={query} />
           </Section>
         ),
       },
-      { id: "bebidasfrias", element: <ColdDrinksSection query={query} /> },
+      {
+        id: "bebidasfrias",
+        element: (
+          <ColdDrinksSection query={query} count={counts.bebidasfrias} />
+        ),
+      },
       {
         id: "postres",
         element: (
-          <Section title="Postres">
+          <Section title="Postres" count={counts.postres}>
             <Desserts query={query} />
           </Section>
         ),
       },
     ],
-    [query]
+    [query, counts]
   );
 
   const renderPanel = (s) => (
@@ -188,7 +193,6 @@ export default function ProductLists({
         <CategoryHeader
           selectedCategory={selectedCategory}
           visibleCount={visibleCount}
-          featureTabs={featureTabs}
         />
         <div className="-mx-4 md:-mx-6 px-4 md:px-6">
           {featureTabs ? (
@@ -210,7 +214,6 @@ export default function ProductLists({
               activeId={selectedCategory}
               onSelect={onCategorySelect}
               variant="chip"
-              counts={counts}
             />
           )}
         </div>

--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -9,7 +9,7 @@ function slugify(s) {
     .replace(/(^-|-$)/g, "");
 }
 
-export default function Section({ title, children }) {
+export default function Section({ title, children, count }) {
   const id = "section-" + slugify(title || "");
   return (
     <section
@@ -19,6 +19,11 @@ export default function Section({ title, children }) {
     >
       <h2 className="text-xl sm:text-2xl font-bold tracking-tight text-neutral-900">
         {title}
+        {count != null && (
+          <span className="ml-2 text-sm text-zinc-500 font-medium align-middle">
+            ({count})
+          </span>
+        )}
       </h2>
       <div className="mt-1 mb-4 sm:mb-5 h-[2px] w-12 rounded bg-[#2f4131]/25" />
       <div className="mt-2 sm:mt-3">{children}</div>


### PR DESCRIPTION
## Summary
- remove badge counts from CategoryBar
- add optional count badges to sections and show count in header
- pass category counts into each section

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad3f4fb8cc832796dd317869d160b7