### PR TITLE
feat: add Todos category to menu navigation

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -49,10 +49,14 @@ export default function CategoryBar({
             <li key={cat.id} className="first:ml-1 last:mr-1">
               <button
                 onClick={() => {
-                  const target = document.getElementById(
-                    cat?.targetId || `section-${cat.id}`
-                  );
-                  target?.scrollIntoView({ behavior: "smooth", block: "start" });
+                  if (cat.id === "todos") {
+                    window.scrollTo({ top: 0, behavior: "smooth" });
+                  } else {
+                    const target = document.getElementById(
+                      cat?.targetId || `section-${cat.id}`
+                    );
+                    target?.scrollIntoView({ behavior: "smooth", block: "start" });
+                  }
                   onSelect?.(cat);
                 }}
                 type="button"

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -210,9 +210,16 @@ export default function ProductLists({
             />
           ) : (
             <CategoryBar
-              categories={categories}
+              categories={[{ id: "todos", label: "Todos" }, ...categories]}
               activeId={selectedCategory}
-              onSelect={onCategorySelect}
+              onSelect={(cat) => {
+                if (cat.id === "todos") {
+                  window.scrollTo({ top: 0, behavior: "smooth" });
+                  onCategorySelect?.({ id: "todos" });
+                } else {
+                  onCategorySelect?.(cat);
+                }
+              }}
               variant="chip"
             />
           )}


### PR DESCRIPTION
## Summary
- add a "Todos" option to CategoryBar to show all categories and scroll to the top
- scroll to top when "Todos" is selected in CategoryBar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad423a36808327a9edb68c1a233449