### PR TITLE
Include postres category in menu navigation

### DIFF
--- a/src/data/menuItems.js
+++ b/src/data/menuItems.js
@@ -6,6 +6,7 @@ export const cats = [
   "smoothies",
   "cafe",
   "bebidasfrias",
+  "postres",
 ];
 
 export const breakfastItems = [


### PR DESCRIPTION
## Summary
- Add `postres` to the category list so desserts are treated as a standard category

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad42f417fc8327a513a5de283b982b