### PR TITLE
Stabilize swipe navigation callbacks to prevent duplicate triggers

### DIFF
--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from "react";
+import { useMemo, useEffect, useCallback } from "react";
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
 import { getStockState, slugify } from "../utils/stock";
@@ -154,32 +154,33 @@ export default function ProductLists({
   const orderedTabs = ["todos", ...cats];
   const activeIndex = Math.max(orderedTabs.indexOf(selectedCategory), 0);
 
-  const swipeHandlers = useSwipeTabs({
-    onPrev: () => {
-      const idx = orderedTabs.indexOf(selectedCategory);
-      if (idx > 0) {
-        const prev = orderedTabs[idx - 1];
-        if (prev === "todos") {
-          onCategorySelect?.({ id: "todos" });
-        } else {
-          const cat = categories.find((c) => c.id === prev);
-          onCategorySelect?.(cat ?? { id: prev });
-        }
+  const onPrev = useCallback(() => {
+    const idx = orderedTabs.indexOf(selectedCategory);
+    if (idx > 0) {
+      const prev = orderedTabs[idx - 1];
+      if (prev === "todos") {
+        onCategorySelect?.({ id: "todos" });
+      } else {
+        const cat = categories.find((c) => c.id === prev);
+        onCategorySelect?.(cat ?? { id: prev });
       }
-    },
-    onNext: () => {
-      const idx = orderedTabs.indexOf(selectedCategory);
-      if (idx >= 0 && idx < orderedTabs.length - 1) {
-        const nxt = orderedTabs[idx + 1];
-        if (nxt === "todos") {
-          onCategorySelect?.({ id: "todos" });
-        } else {
-          const cat = categories.find((c) => c.id === nxt);
-          onCategorySelect?.(cat ?? { id: nxt });
-        }
+    }
+  }, [selectedCategory, categories, onCategorySelect]);
+
+  const onNext = useCallback(() => {
+    const idx = orderedTabs.indexOf(selectedCategory);
+    if (idx >= 0 && idx < orderedTabs.length - 1) {
+      const nxt = orderedTabs[idx + 1];
+      if (nxt === "todos") {
+        onCategorySelect?.({ id: "todos" });
+      } else {
+        const cat = categories.find((c) => c.id === nxt);
+        onCategorySelect?.(cat ?? { id: nxt });
       }
-    },
-  });
+    }
+  }, [selectedCategory, categories, onCategorySelect]);
+
+  const swipeHandlers = useSwipeTabs({ onPrev, onNext });
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" });

--- a/src/utils/useSwipeTabs.js
+++ b/src/utils/useSwipeTabs.js
@@ -1,42 +1,54 @@
-import { useRef } from "react";
+import { useRef, useEffect, useCallback, useMemo } from "react";
 
 export default function useSwipeTabs({ onPrev, onNext, threshold = 40 } = {}) {
   const startX = useRef(0);
   const startY = useRef(0);
   const triggered = useRef(false);
+  const onPrevRef = useRef(onPrev);
+  const onNextRef = useRef(onNext);
 
-  function onTouchStart(e) {
+  useEffect(() => {
+    onPrevRef.current = onPrev;
+  }, [onPrev]);
+
+  useEffect(() => {
+    onNextRef.current = onNext;
+  }, [onNext]);
+
+  const onTouchStart = useCallback((e) => {
+    if (triggered.current) return;
     const t = e.touches && e.touches[0];
     if (!t) return;
     startX.current = t.clientX;
     startY.current = t.clientY;
-    triggered.current = false;
-  }
+  }, []);
 
-  function onTouchMove(e) {
-    if (triggered.current) return;
-    const t = e.touches && e.touches[0];
-    if (!t) return;
-    const dx = t.clientX - startX.current;
-    const dy = t.clientY - startY.current;
-    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > threshold) {
-      triggered.current = true;
-      if (dx > 0) {
-        onPrev?.();
-      } else {
-        onNext?.();
+  const onTouchMove = useCallback(
+    (e) => {
+      if (triggered.current) return;
+      const t = e.touches && e.touches[0];
+      if (!t) return;
+      const dx = t.clientX - startX.current;
+      const dy = t.clientY - startY.current;
+      if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > threshold) {
+        triggered.current = true;
+        if (dx > 0) {
+          onPrevRef.current?.();
+        } else {
+          onNextRef.current?.();
+        }
       }
-    }
-  }
+    },
+    [threshold]
+  );
 
-  function onTouchEnd() {
+  const onTouchEnd = useCallback(() => {
     triggered.current = false;
-  }
+  }, []);
 
-  return {
-    onTouchStart,
-    onTouchMove,
-    onTouchEnd,
-  };
+  return useMemo(
+    () => ({ onTouchStart, onTouchMove, onTouchEnd }),
+    [onTouchStart, onTouchMove, onTouchEnd]
+  );
 }
 


### PR DESCRIPTION
## Summary
- Wrap `onPrev` and `onNext` with `useCallback` to supply stable handlers
- Rewrite `useSwipeTabs` to keep stable refs and ignore swipes while navigating

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `node -e "import React from 'react'; import {renderToString} from 'react-dom/server'; import useSwipeTabs from './src/utils/useSwipeTabs.js'; function Test(){ const handlers=useSwipeTabs({onPrev:()=>{console.log('prev')}, onNext:()=>{console.log('next')}}); handlers.onTouchStart({touches:[{clientX:50,clientY:0}]}); handlers.onTouchMove({touches:[{clientX:100,clientY:0}]}); handlers.onTouchEnd(); handlers.onTouchStart({touches:[{clientX:50,clientY:0}]}); handlers.onTouchMove({touches:[{clientX:0,clientY:0}]}); handlers.onTouchEnd(); return null;} renderToString(React.createElement(Test));"`

------
https://chatgpt.com/codex/tasks/task_e_68ad46e73cbc8327b174f4d58b55e1c0