### PR TITLE
Remove unused quantity argument when adding promo banner product

### DIFF
--- a/src/components/PromoBannerCarousel.jsx
+++ b/src/components/PromoBannerCarousel.jsx
@@ -91,7 +91,7 @@ export default function PromoBannerCarousel({ items = [], resolveProductById }) 
                       <div className="mt-2 flex gap-2">
                         <button
                           type="button"
-                          onClick={() => canAdd && addItem(product, 1)}
+                          onClick={() => canAdd && addItem(product)}
                           aria-label={addLabel}
                           disabled={!canAdd}
                           aria-disabled={!canAdd}


### PR DESCRIPTION
## Summary
- fix add button in promo banner to call `addItem` with correct arguments

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ad48d5e13c832792d255ccfdc41609