### PR TITLE
fix: ensure unique ARIA associations

### DIFF
--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -71,7 +71,9 @@ export default function CategoryTabs({ value, onChange, items = [] }) {
               id={`tab-${item.id}`}
               role="tab"
               aria-selected={selected}
-              aria-controls={`panel-${item.id}`}
+              aria-controls={
+                item.id === "todos" ? undefined : `panel-${item.id}`
+              }
               tabIndex={selected ? 0 : -1}
               onKeyDown={(e) => handleKeyDown(e, idx)}
               onClick={() => onChange?.(item.id)}

--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -41,7 +41,7 @@ function Card({ item, onAdd }) {
   );
 }
 
-export default function ColdDrinksSection({ query, count }) {
+export default function ColdDrinksSection({ query, count, id }) {
   const { addItem } = useCart();
 
   const sodasFiltered = (sodas || []).filter((it) =>
@@ -53,7 +53,7 @@ export default function ColdDrinksSection({ query, count }) {
   if (!sodasFiltered.length && !othersFiltered.length) return null;
 
   return (
-    <Section title="Bebidas frías" count={count}>
+    <Section title="Bebidas frías" count={count} id={id}>
       {sodasFiltered.length > 0 && (
         <>
           {/* Subgrupo: Gaseosas y Sodas */}

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   useLayoutEffect,
+  cloneElement,
 } from "react";
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
@@ -159,7 +160,9 @@ export default function ProductLists({
           {categories.find((c) => c.id === s.id)?.label || s.id}
         </span>
       )}
-      {s.element}
+      {inTodos
+        ? cloneElement(s.element, { id: `section-${s.id}-todos` })
+        : s.element}
     </div>
   );
 

--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -9,8 +9,8 @@ function slugify(s) {
     .replace(/(^-|-$)/g, "");
 }
 
-export default function Section({ title, children, count }) {
-  const id = "section-" + slugify(title || "");
+export default function Section({ title, children, count, id: customId }) {
+  const id = customId ?? "section-" + slugify(title || "");
   return (
     <section
       id={id}


### PR DESCRIPTION
## Summary
- avoid invalid panel references in `CategoryTabs`
- allow overriding section IDs for `ProductLists` panels
- forward custom IDs through `ColdDrinksSection`

## Testing
- `npm run build`
- `node <<'NODE' ... axe run ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68ad508d2aac8327814709fd6f3cafd2