### PR TITLE
Reduce extra spacing in tabbed categories

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -191,17 +191,26 @@ export default function App() {
     return <QrPoster url={publicUrl} />;
   }
 
+  const hasFloatingCartBar = cart.items && cart.items.length > 0;
+
   // ✅ Modo menú normal
   return (
     <div className="bg-alto-beige text-alto-text leading-snug">
       <Header onCartOpen={() => setOpen(true)} onGuideOpen={() => setOpenGuide(true)} />
 
-      <div className="mx-auto max-w-3xl p-5 sm:p-6 md:p-8">
+      <main
+        className={`mx-auto max-w-3xl px-5 sm:px-6 md:px-8 pt-5 sm:pt-6 md:pt-8 ${
+          hasFloatingCartBar ? "pb-24" : "pb-8"
+        }`}
+      >
         <div className="mt-2 mb-6">
           <HeroHeadline />
           <SearchBar value={query} onQueryChange={setQuery} />
         </div>
-        <PromoBannerCarousel items={banners} resolveProductById={resolveProductById} />
+        <PromoBannerCarousel
+          items={banners}
+          resolveProductById={resolveProductById}
+        />
         <ProductLists
           query={query}
           selectedCategory={selectedCategory}
@@ -211,15 +220,15 @@ export default function App() {
         />
 
         <Footer />
+      </main>
 
-        {/* Barra flotante y Drawer del carrito */}
-        <FloatingCartBar
-          items={cart.items}
-          total={cart.total}
-          onOpen={() => setOpen(true)}
-        />
-        <CartDrawer open={open} onClose={() => setOpen(false)} />
-      </div>
+      {/* Barra flotante y Drawer del carrito */}
+      <FloatingCartBar
+        items={cart.items}
+        total={cart.total}
+        onOpen={() => setOpen(true)}
+      />
+      <CartDrawer open={open} onClose={() => setOpen(false)} />
 
       <GuideModal open={openGuide} onClose={() => setOpenGuide(false)}>
         <DietaryGuide />

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -147,25 +147,6 @@ export default function ProductLists({
     [query, counts]
   );
 
-  const renderPanel = (s, inTodos = false) => (
-    <div
-      key={s.id}
-      id={`panel-${s.id}${inTodos ? "-todos" : ""}`}
-      role="tabpanel"
-      tabIndex={-1}
-      aria-labelledby={`tab-${s.id}${inTodos ? "-todos" : ""}`}
-    >
-      {inTodos && (
-        <span id={`tab-${s.id}-todos`} className="sr-only">
-          {categories.find((c) => c.id === s.id)?.label || s.id}
-        </span>
-      )}
-      {inTodos
-        ? cloneElement(s.element, { id: `section-${s.id}-todos` })
-        : s.element}
-    </div>
-  );
-
   const orderedTabs = ["todos", ...cats];
   const activeIndex = Math.max(orderedTabs.indexOf(selectedCategory), 0);
 
@@ -211,13 +192,18 @@ export default function ProductLists({
     window.scrollTo({ top: 0, behavior: "smooth" });
   }, [selectedCategory]);
 
+  const sectionStackClass =
+    featureTabs && selectedCategory !== "todos" ? "" : "space-y-6";
+
   return (
     <>
       <div className="mx-auto max-w-screen-md px-4 md:px-6">
-        <CategoryHeader
-          selectedCategory={selectedCategory}
-          visibleCount={visibleCount}
-        />
+        {!featureTabs && (
+          <CategoryHeader
+            selectedCategory={selectedCategory}
+            visibleCount={visibleCount}
+          />
+        )}
         <div className="-mx-4 md:-mx-6 px-4 md:px-6">
           {featureTabs ? (
             <CategoryTabs
@@ -266,11 +252,24 @@ export default function ProductLists({
                 if (el) panelRefs.current[id] = el;
               }}
             >
-              {id === "todos"
-                ? sections.map((s) => renderPanel(s, true))
-                : sections
-                    .filter((s) => s.id === id)
-                    .map((s) => renderPanel(s))}
+              <div
+                id={`panel-${id}`}
+                role="tabpanel"
+                tabIndex={-1}
+                aria-labelledby={`tab-${id}`}
+                className={sectionStackClass}
+              >
+                {id === "todos"
+                  ? sections.map((s) =>
+                      cloneElement(s.element, {
+                        id: `section-${s.id}-todos`,
+                        key: s.id,
+                      })
+                    )
+                  : sections
+                      .filter((s) => s.id === id)
+                      .map((s) => cloneElement(s.element, { key: s.id }))}
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -15,7 +15,7 @@ export default function Section({ title, children, count, id: customId }) {
     <section
       id={id}
       data-aa-section={title}
-      className="scroll-mt-24 mt-6 sm:mt-8"
+      className="scroll-mt-24 mb-6 last:mb-0"
     >
       <h2 className="text-xl sm:text-2xl font-bold tracking-tight text-neutral-900">
         {title}


### PR DESCRIPTION
## Summary
- avoid duplicate category header when tabs are enabled
- adjust section spacing and stack handling for tab panels
- add page-level bottom padding only when floating cart bar is visible

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad551b5d0c83278dff99b17a0e8ddf