### PR TITLE
Renderizar un panel de categoría a la vez y mejorar composición

### DIFF
--- a/src/components/BowlBuilderModal.jsx
+++ b/src/components/BowlBuilderModal.jsx
@@ -207,12 +207,14 @@ export default function BowlBuilderModal({ open, onClose }) {
             </div>
             <div className="flex gap-2">
               <button
+                type="button"
                 className="h-8 px-3 rounded-full bg-white text-[#2f4131] hover:bg-white/90 text-sm"
                 onClick={resetAll}
               >
                 Restablecer
               </button>
               <button
+                type="button"
                 onClick={onClose}
                 className="text-white/95 underline underline-offset-2 text-sm"
               >
@@ -337,12 +339,14 @@ export default function BowlBuilderModal({ open, onClose }) {
           </div>
           <div className="flex gap-2 pt-2">
             <button
+              type="button"
               onClick={onClose}
               className="flex-1 h-9 rounded-lg bg-white/10 text-white hover:bg-white/15 ring-1 ring-white/15 text-sm"
             >
               Seguir pidiendo
             </button>
             <button
+              type="button"
               onClick={addToCart}
               className="flex-1 h-9 rounded-lg bg-[#2f4131] text-white hover:bg-[#243326] text-sm"
             >

--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -75,6 +75,7 @@ export default function BowlsSection({ query }) {
             Desde {formatCOP(BASE_PRICE)}
           </div>
           <button
+            type="button"
             onClick={openBuilder}
             aria-label="Armar bowl personalizado"
             className={[

--- a/src/components/Buttons.jsx
+++ b/src/components/Buttons.jsx
@@ -5,6 +5,7 @@ export function Chip({ active, onClick, children, className = "", shape = "pill"
   const rounded = shape === "card" ? "rounded-xl" : "rounded-full";
   return (
     <button
+      type="button"
       onClick={onClick}
       className={cx(
         "px-3 py-1 text-sm border transition",
@@ -20,9 +21,9 @@ export function Chip({ active, onClick, children, className = "", shape = "pill"
   );
 }
 
-export function Button({ variant = "primary", className = "", ...props }) {
+export function Button({ variant = "primary", className = "", type = "button", ...props }) {
   const base = "btn " + (variant === "primary" ? "btn-primary" : "btn-outline");
-  return <button {...props} className={base + " " + className} />;
+  return <button type={type} {...props} className={base + " " + className} />;
 }
 
 // Botón de texto “Añadir” (no-FAB)

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -237,6 +237,7 @@ export default function CoffeeSection({ query }) {
                   <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2">
                     {showAddMilk && (
                       <button
+                        type="button"
                         className="text-xs text-alto-primary underline text-left"
                         onClick={() => toggleAddMilk(item.id)}
                       >

--- a/src/components/FloatingCartBar.jsx
+++ b/src/components/FloatingCartBar.jsx
@@ -18,6 +18,7 @@ export default function FloatingCartBar({ items, total, onOpen, secondaryAction,
             <div className="flex items-center gap-2">
               {secondaryAction && secondaryLabel && (
                 <button
+                  type="button"
                   onClick={secondaryAction}
                   className="h-10 px-3 rounded-xl bg-white/10 text-white hover:bg-white/15 ring-1 ring-white/15"
                 >
@@ -28,6 +29,7 @@ export default function FloatingCartBar({ items, total, onOpen, secondaryAction,
                 Total actualizado: {total?.toLocaleString?.("es-CO", { style: "currency", currency: "COP" })}
               </span>
               <button
+                type="button"
                 onClick={onOpen}
                 className="h-10 px-4 rounded-xl bg-[#2f4131] text-white hover:bg-[#243326] transition focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
               >

--- a/src/components/GuideModal.jsx
+++ b/src/components/GuideModal.jsx
@@ -18,6 +18,7 @@ export default function GuideModal({ open, onClose, children }) {
       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
       <div className="relative max-w-md w-[92%] rounded-2xl bg-[#FAF7F2] p-5 shadow-lg">
         <button
+          type="button"
           onClick={onClose}
           aria-label="Cerrar"
           className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -1,12 +1,4 @@
-import {
-  useMemo,
-  useEffect,
-  useCallback,
-  useRef,
-  useState,
-  useLayoutEffect,
-  cloneElement,
-} from "react";
+import { useMemo, useEffect, useCallback, cloneElement } from "react";
 import { useCart } from "../context/CartContext";
 import { COP } from "../utils/money";
 import { getStockState, slugify } from "../utils/stock";
@@ -146,7 +138,6 @@ export default function ProductLists({
     ],
     [query, counts]
   );
-
   const renderPanel = (s, inTodos = false) => (
     <div
       key={s.id}
@@ -154,6 +145,7 @@ export default function ProductLists({
       role="tabpanel"
       tabIndex={-1}
       aria-labelledby={`tab-${s.id}${inTodos ? "-todos" : ""}`}
+      className="will-change-transform [transform:translateZ(0)] contain-content overscroll-y-contain"
     >
       {inTodos && (
         <span id={`tab-${s.id}-todos`} className="sr-only">
@@ -167,17 +159,6 @@ export default function ProductLists({
   );
 
   const orderedTabs = ["todos", ...cats];
-  const activeIndex = Math.max(orderedTabs.indexOf(selectedCategory), 0);
-
-  const panelRefs = useRef({});
-  const [activeHeight, setActiveHeight] = useState();
-
-  useLayoutEffect(() => {
-    const el = panelRefs.current[selectedCategory];
-    if (el) {
-      setActiveHeight(el.offsetHeight);
-    }
-  }, [selectedCategory, counts, query]);
 
   const onPrev = useCallback(() => {
     const idx = orderedTabs.indexOf(selectedCategory);
@@ -210,6 +191,9 @@ export default function ProductLists({
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" });
   }, [selectedCategory]);
+
+  const stackClass =
+    featureTabs && selectedCategory !== "todos" ? "" : "space-y-6";
 
   return (
     <>
@@ -251,29 +235,14 @@ export default function ProductLists({
       </div>
       <div
         {...swipeHandlers}
-        className="overflow-hidden"
-        style={{ height: activeHeight }}
+        className={stackClass}
       >
-        <div
-          className="flex transition-transform duration-300 ease-in-out"
-          style={{ transform: `translateX(-${activeIndex * 100}%)` }}
-        >
-          {orderedTabs.map((id) => (
-            <div
-              key={id}
-              className="w-full flex-shrink-0"
-              ref={(el) => {
-                if (el) panelRefs.current[id] = el;
-              }}
-            >
-              {id === "todos"
-                ? sections.map((s) => renderPanel(s, true))
-                : sections
-                    .filter((s) => s.id === id)
-                    .map((s) => renderPanel(s))}
-            </div>
-          ))}
-        </div>
+        {sections.map((s) => {
+          if (featureTabs && selectedCategory !== "todos" && s.id !== selectedCategory) {
+            return null;
+          }
+          return renderPanel(s, selectedCategory === "todos");
+        })}
       </div>
     </>
   );

--- a/src/components/ProductQuickView.jsx
+++ b/src/components/ProductQuickView.jsx
@@ -36,6 +36,7 @@ export default function ProductQuickView({ product, open, onClose }) {
       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
       <div className="relative max-w-sm w-[92%] rounded-2xl bg-white ring-1 ring-neutral-200 shadow-lg">
         <button
+          type="button"
           onClick={onClose}
           aria-label="Cerrar"
           className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"

--- a/src/components/PromoBannerCarousel.jsx
+++ b/src/components/PromoBannerCarousel.jsx
@@ -43,12 +43,9 @@ export default function PromoBannerCarousel({ items = [], resolveProductById }) 
   };
 
   return (
-    <div
-      className="relative rounded-2xl overflow-hidden"
-      aria-roledescription="carousel"
-    >
+    <div className="relative" aria-roledescription="carousel">
       <div
-        className="relative overflow-hidden"
+        className="relative"
         onMouseEnter={() => setPaused(true)}
         onMouseLeave={() => setPaused(false)}
         onTouchStart={onTouchStart}
@@ -79,7 +76,7 @@ export default function PromoBannerCarousel({ items = [], resolveProductById }) 
                     loading="lazy"
                     referrerPolicy="no-referrer"
                     decoding="async"
-                    className="absolute inset-0 h-full w-full object-cover z-0"
+                    className="absolute inset-0 w-full h-full object-cover z-0"
                   />
                   <div className="absolute inset-0 z-10 pointer-events-none bg-gradient-to-t from-black/55 via-black/20 to-transparent" />
                   <div className="relative z-30 pointer-events-auto flex h-full w-full flex-col justify-end p-4">
@@ -129,7 +126,7 @@ export default function PromoBannerCarousel({ items = [], resolveProductById }) 
                     <div
                       aria-label="Precio"
                       tabIndex={-1}
-                      className="absolute top-3 right-3 md:top-4 md:right-4 z-30 rounded-full px-3 py-1 text-sm bg-white/85 backdrop-blur shadow-sm text-[#2f4131] font-medium"
+                      className="absolute top-3 right-3 md:top-4 md:right-4 z-30 rounded-full px-3 py-1 text-sm bg-white/85 shadow-sm text-[#2f4131] font-medium pointer-events-auto"
                     >
                       {cop(price)}
                     </div>
@@ -144,6 +141,7 @@ export default function PromoBannerCarousel({ items = [], resolveProductById }) 
           {items.map((_, i) => (
             <button
               key={i}
+              type="button"
               onClick={() => setIndex(i)}
               aria-label={`Ir al banner ${i + 1}`}
               className={`h-2 w-2 rounded-full ${i === index ? "bg-white" : "bg-white/50"} focus:outline-none focus:ring-2 focus:ring-white`}

--- a/src/components/QrPoster.jsx
+++ b/src/components/QrPoster.jsx
@@ -47,12 +47,14 @@ export default function QrPoster({ url }) {
 
         <div className="mt-5 flex gap-2 justify-center no-print">
           <button
+            type="button"
             className="px-3 py-2 rounded-lg border bg-neutral-50 hover:bg-neutral-100 text-sm"
             onClick={handleCopy}
           >
             Copiar URL
           </button>
           <button
+            type="button"
             className="px-3 py-2 rounded-lg bg-alto-primary text-white hover:opacity-90 text-sm"
             onClick={handlePrint}
           >


### PR DESCRIPTION
## Summary
- Renderiza solo la sección activa en modo tabs y elimina el espaciado extra cuando hay un único panel.
- Ajusta PromoBannerCarousel para evitar glitches de composición y define capas claras para imagen, overlay y contenido.
- Marca los botones interactivos con `type="button"` para que los CTAs sigan siendo clicables.

## Testing
- `npm test` *(missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad5511fc5c8327a5d8b0ac7678eb04