### PR TITLE
feat: improve category bar layout and icons

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -27,19 +27,20 @@ export default function CategoryBar({
   activeId,
   onSelect,
   variant = "chip",
+  fullBleed = true,
 }) {
   const baseItemClasses =
     variant === "chip"
       ? "flex-none w-[100px] basis-[100px] h-[110px] snap-start rounded-xl bg-white/60 backdrop-blur-sm transition-colors transition-shadow duration-150 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,.3)] focus:ring-offset-2"
       : "flex-none shrink-0 basis-[112px] w-[112px] h-[128px]";
   const labelHeight = variant === "chip" ? "h-[34px]" : "h-[38px]";
-  return (
+  const nav = (
     <nav
       className="sticky z-[60] px-0 w-full"
       style={{ top: "env(safe-area-inset-top, 0px)" }}
       aria-label="Categorías del menú"
     >
-      <ul className="flex overflow-x-auto snap-x snap-mandatory gap-3 py-2 [transform:translateZ(0)] w-full">
+      <ul className="flex overflow-x-auto scrollbar-none snap-x snap-mandatory gap-3 scroll-px-4 py-2 [transform:translateZ(0)]">
         {categories.map((cat) => {
           const active = activeId === cat.id;
           const tint = cat.tintClass || "bg-zinc-100";
@@ -119,5 +120,10 @@ export default function CategoryBar({
       </ul>
     </nav>
   );
+
+  if (fullBleed) {
+    return <div className="-mx-4 md:-mx-6 px-4 md:px-6">{nav}</div>;
+  }
+  return nav;
 }
 

--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -18,7 +18,7 @@ function IconWithFallback({ icon, size = 32, className }) {
   );
 }
 
-export default function CategoryTabs({ value, onChange, items = [] }) {
+export default function CategoryTabs({ value, onChange, items = [], fullBleed = true }) {
   const tabRefs = useRef([]);
   const baseItemClasses =
     "flex-none w-[100px] basis-[100px] h-[110px] snap-start rounded-xl bg-white/60 backdrop-blur-sm transition-colors transition-shadow duration-150 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,.3)] focus:ring-offset-2";
@@ -51,7 +51,7 @@ export default function CategoryTabs({ value, onChange, items = [] }) {
     }
   }
 
-  return (
+  const nav = (
     <nav
       className="sticky z-[60] px-0"
       style={{ top: "env(safe-area-inset-top, 0px)" }}
@@ -59,32 +59,35 @@ export default function CategoryTabs({ value, onChange, items = [] }) {
     >
       <div
         role="tablist"
-        className="flex overflow-x-auto snap-x snap-mandatory gap-3 py-2 [transform:translateZ(0)]"
+        className="flex overflow-x-auto scrollbar-none snap-x snap-mandatory gap-3 scroll-px-4 py-2 [transform:translateZ(0)]"
       >
         {items.map((item, idx) => {
           const selected = value === item.id;
+          const tint = item.tintClass || "bg-zinc-100";
           return (
-            <button
-              key={item.id}
-              ref={(el) => (tabRefs.current[idx] = el)}
-              type="button"
-              id={`tab-${item.id}`}
-              role="tab"
-              aria-selected={selected}
-              aria-controls={
-                item.id === "todos" ? undefined : `panel-${item.id}`
-              }
-              tabIndex={selected ? 0 : -1}
-              onKeyDown={(e) => handleKeyDown(e, idx)}
-              onClick={() => onChange?.(item.id)}
-              className={`${baseItemClasses} first:ml-1 last:mr-1 flex flex-col items-center justify-center text-center ${
-                selected
-                  ? "border border-transparent bg-white/55 shadow-[inset_0_1px_0_rgba(255,255,255,.65),_0_8px_22px_rgba(36,51,38,.16)] text-[#2f4131]"
-                  : "border border-zinc-200 hover:border-zinc-300"
-              }`}
-            >
+              <button
+                key={item.id}
+                ref={(el) => (tabRefs.current[idx] = el)}
+                type="button"
+                id={`tab-${item.id}`}
+                role="tab"
+                aria-selected={selected}
+                aria-label={item.label}
+                aria-current={selected ? "true" : undefined}
+                aria-controls={
+                  item.id === "todos" ? undefined : `panel-${item.id}`
+                }
+                tabIndex={selected ? 0 : -1}
+                onKeyDown={(e) => handleKeyDown(e, idx)}
+                onClick={() => onChange?.(item.id)}
+                className={`${baseItemClasses} first:ml-1 last:mr-1 flex flex-col items-center justify-center text-center ${
+                  selected
+                    ? "border border-transparent bg-white/55 shadow-[inset_0_1px_0_rgba(255,255,255,.65),_0_8px_22px_rgba(36,51,38,.16)] text-[#2f4131]"
+                    : "border border-zinc-200 hover:border-zinc-300"
+                }`}
+              >
               <span
-                className={`grid place-items-center h-11 w-11 md:h-12 md:w-12 rounded-full bg-zinc-100 ${
+                className={`grid place-items-center h-11 w-11 md:h-12 md:w-12 rounded-full ${tint} ${
                   selected ? "shadow-[inset_0_1px_0_rgba(255,255,255,.75)]" : ""
                 }`}
               >
@@ -118,4 +121,9 @@ export default function CategoryTabs({ value, onChange, items = [] }) {
       </div>
     </nav>
   );
+
+  if (fullBleed) {
+    return <div className="-mx-4 md:-mx-6 px-4 md:px-6">{nav}</div>;
+  }
+  return nav;
 }

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -33,25 +33,33 @@ export default function ProductLists({
   const visibleCount = counts[selectedCategory] ?? 0;
   const categories = useMemo(
     () => [
-      { id: "desayunos", label: "Desayunos" },
-      { id: "bowls", label: "Bowls" },
+      { id: "desayunos", label: "Desayunos", tintClass: "bg-amber-50" },
+      { id: "bowls", label: "Bowls", tintClass: "bg-emerald-50" },
       {
         id: "platos",
         label: "Platos Fuertes",
         targetId: "section-platos-fuertes",
+        tintClass: "bg-violet-50",
       },
-      { id: "sandwiches", label: "Sándwiches" },
+      { id: "sandwiches", label: "Sándwiches", tintClass: "bg-rose-50" },
       {
         id: "smoothies",
         label: "Smoothies & Funcionales",
         targetId: "section-smoothies-funcionales",
+        tintClass: "bg-pink-50",
       },
       {
         id: "cafe",
         label: "Café de especialidad",
         targetId: "section-cafe-de-especialidad",
+        tintClass: "bg-stone-200",
       },
-      { id: "bebidasfrias", label: "Bebidas frías", targetId: "section-bebidas-frias" },
+      {
+        id: "bebidasfrias",
+        label: "Bebidas frías",
+        targetId: "section-bebidas-frias",
+        tintClass: "bg-sky-50",
+      },
       { id: "postres", label: "Postres" },
     ],
     [query]
@@ -61,12 +69,18 @@ export default function ProductLists({
     () =>
       CATS.map((slug) => {
         if (slug === "todos")
-          return { id: "todos", label: "Todos", icon: "fluent-emoji:bookmark-tabs" };
+          return {
+            id: "todos",
+            label: "Todos",
+            icon: "ph:squares-four",
+            tintClass: "bg-stone-100",
+          };
         const cat = categories.find((c) => c.id === slug);
         return {
           id: slug,
           label: cat?.label || slug,
           icon: categoryIcons[slug],
+          tintClass: cat?.tintClass,
         };
       }),
     [categories]
@@ -201,43 +215,41 @@ export default function ProductLists({
 
   return (
     <>
-      <div className="mx-auto max-w-screen-md px-4 md:px-6">
+      <div className="mx-auto max-w-screen-md">
         {!featureTabs && (
           <CategoryHeader
             selectedCategory={selectedCategory}
             visibleCount={visibleCount}
           />
         )}
-        <div className="-mx-4 md:-mx-6 px-4 md:px-6">
-          {featureTabs ? (
-            <CategoryTabs
-              items={tabItems}
-              value={selectedCategory}
-              onChange={(slug) => {
-                if (slug === "todos") {
-                  onCategorySelect?.({ id: "todos" });
-                } else {
-                  const cat = categories.find((c) => c.id === slug);
-                  onCategorySelect?.(cat ?? { id: "todos" });
-                }
-              }}
-            />
-          ) : (
-            <CategoryBar
-              categories={[{ id: "todos", label: "Todos" }, ...categories]}
-              activeId={selectedCategory}
-              onSelect={(cat) => {
-                if (cat.id === "todos") {
-                  window.scrollTo({ top: 0, behavior: "smooth" });
-                  onCategorySelect?.({ id: "todos" });
-                } else {
-                  onCategorySelect?.(cat);
-                }
-              }}
-              variant="chip"
-            />
-          )}
-        </div>
+        {featureTabs ? (
+          <CategoryTabs
+            items={tabItems}
+            value={selectedCategory}
+            onChange={(slug) => {
+              if (slug === "todos") {
+                onCategorySelect?.({ id: "todos" });
+              } else {
+                const cat = categories.find((c) => c.id === slug);
+                onCategorySelect?.(cat ?? { id: "todos" });
+              }
+            }}
+          />
+        ) : (
+          <CategoryBar
+            categories={[{ id: "todos", label: "Todos", tintClass: "bg-stone-100" }, ...categories]}
+            activeId={selectedCategory}
+            onSelect={(cat) => {
+              if (cat.id === "todos") {
+                window.scrollTo({ top: 0, behavior: "smooth" });
+                onCategorySelect?.({ id: "todos" });
+              } else {
+                onCategorySelect?.(cat);
+              }
+            }}
+            variant="chip"
+          />
+        )}
       </div>
       <div
         {...swipeHandlers}

--- a/src/data/categoryIcons.js
+++ b/src/data/categoryIcons.js
@@ -1,4 +1,5 @@
 export const categoryIcons = {
+  todos: "ph:squares-four",
   desayunos: "fluent-emoji:croissant",
   bowls: "fluent-emoji:pot-of-food",
   platos: "fluent-emoji:fork-and-knife-with-plate",

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,6 +7,15 @@
   color-scheme: light;
 }
 
+/* Oculta scrollbar en contenedores horizontales de categorías */
+.scrollbar-none {
+  -ms-overflow-style: none; /* IE/Edge */
+  scrollbar-width: none; /* Firefox */
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none; /* Chrome/Safari */
+}
+
 .card {
   @apply rounded-2xl border border-alto-greige bg-alto-warmwhite shadow-card;
 }


### PR DESCRIPTION
## Summary
- make category bar full-bleed with optional control and hidden scrollbar
- tint category chips and add icon for Todos

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68add46547fc8327a6f5fbea3be38a63