### PR TITLE
fix: avoid page scroll when switching categories in tab mode

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -2,8 +2,6 @@ import { useState } from "react";
 import { Icon } from "@iconify-icon/react";
 import { categoryIcons } from "../data/categoryIcons";
 
-const FEATURE_TABS = import.meta.env.VITE_FEATURE_TABS === "1";
-
 function IconWithFallback({ id, size = 32, className }) {
   const entry = categoryIcons[id];
   const initial = typeof entry === "string" ? entry : entry?.icon;
@@ -28,6 +26,7 @@ export default function CategoryBar({
   onSelect,
   variant = "chip",
   fullBleed = true,
+  featureTabs = false,
 }) {
   const baseItemClasses =
     variant === "chip"
@@ -48,25 +47,34 @@ export default function CategoryBar({
             variant === "chip"
               ? `text-[13px] leading-tight ${active ? "text-[#2f4131]" : "text-zinc-800"}`
               : "text-[12px] leading-tight";
+          const onClickItem = (e) => {
+            e?.preventDefault?.();
+            e?.stopPropagation?.();
+
+            if (featureTabs) {
+              onSelect?.(cat);
+              return;
+            }
+
+            if (cat.id === "todos") {
+              window.scrollTo({ top: 0, behavior: "smooth" });
+            } else {
+              const target = document.getElementById(
+                cat?.targetId || `section-${cat.id}`
+              );
+              target?.scrollIntoView({
+                behavior: "smooth",
+                block: "start",
+              });
+            }
+
+            onSelect?.(cat);
+          };
+
           return (
             <li key={cat.id} className="first:ml-1 last:mr-1">
               <button
-                onClick={() => {
-                  if (!FEATURE_TABS) {
-                    if (cat.id === "todos") {
-                      window.scrollTo({ top: 0, behavior: "smooth" });
-                    } else {
-                      const target = document.getElementById(
-                        cat?.targetId || `section-${cat.id}`
-                      );
-                      target?.scrollIntoView({
-                        behavior: "smooth",
-                        block: "start",
-                      });
-                    }
-                  }
-                  onSelect?.(cat);
-                }}
+                onClick={(e) => onClickItem(e)}
                 type="button"
                 aria-label={cat.label}
                 aria-current={active ? "true" : undefined}

--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -18,7 +18,13 @@ function IconWithFallback({ icon, size = 32, className }) {
   );
 }
 
-export default function CategoryTabs({ value, onChange, items = [], fullBleed = true }) {
+export default function CategoryTabs({
+  value,
+  onChange,
+  items = [],
+  fullBleed = true,
+  featureTabs = true,
+}) {
   const tabRefs = useRef([]);
   const baseItemClasses =
     "flex-none w-[100px] basis-[100px] h-[110px] snap-start rounded-xl bg-white/60 backdrop-blur-sm transition-colors transition-shadow duration-150 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,.3)] focus:ring-offset-2";

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -234,20 +234,15 @@ export default function ProductLists({
                 onCategorySelect?.(cat ?? { id: "todos" });
               }
             }}
+            featureTabs={featureTabs}
           />
         ) : (
           <CategoryBar
             categories={[{ id: "todos", label: "Todos", tintClass: "bg-stone-100" }, ...categories]}
             activeId={selectedCategory}
-            onSelect={(cat) => {
-              if (cat.id === "todos") {
-                window.scrollTo({ top: 0, behavior: "smooth" });
-                onCategorySelect?.({ id: "todos" });
-              } else {
-                onCategorySelect?.(cat);
-              }
-            }}
+            onSelect={(cat) => onCategorySelect?.(cat)}
             variant="chip"
+            featureTabs={featureTabs}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- Convert category items to buttons with guarded scrolling
- Pass feature flag to tabs/bar components and remove legacy scroll handlers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68add789fdf0832793e43aa2d0be587b