### PR TITLE
Integrate banner data and product resolver into promo carousel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,6 @@ import DietaryGuide from "./components/DietaryGuide";
 import FloatingCartBar from "./components/FloatingCartBar";
 import CartDrawer from "./components/CartDrawer";
 import { useCart } from "./context/CartContext";
-import { banners as buildBanners } from "./data/banners";
 import {
   breakfastItems,
   mainDishes,
@@ -46,7 +45,6 @@ export default function App() {
   const [query, setQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("todos");
   const cart = useCart();
-  const banners = buildBanners(import.meta.env);
 
   function handleCategorySelect(cat) {
     const slug = typeof cat === "string" ? cat : cat.id;
@@ -68,66 +66,6 @@ export default function App() {
     url.searchParams.set("cat", selectedCategory);
     window.history.replaceState(null, "", url);
   }, [FEATURE_TABS, selectedCategory]);
-
-  const productMap = useMemo(() => {
-    const collections = [
-      breakfastItems,
-      mainDishes,
-      dessertBaseItems,
-      [preBowl],
-      smoothies,
-      funcionales,
-      coffees,
-      infusions,
-      sodas,
-      otherDrinks,
-    ];
-    if (sandwichItems && sandwichPriceByItem) {
-      const mapped = sandwichItems.map((it) => {
-        const mapping = sandwichPriceByItem[it.key];
-        const price = mapping?.unico ?? mapping?.clasico ?? mapping?.grande;
-        return { id: "sandwich:" + it.key, name: it.name, price, desc: it.desc };
-      });
-      collections.push(mapped);
-    }
-    const map = {};
-    for (const col of collections) {
-      if (!Array.isArray(col)) continue;
-      for (const p of col) {
-        const pid = p.id || p.productId;
-        if (!pid) continue;
-        const prod = {
-          ...p,
-          id: pid,
-          productId: pid,
-          name: p.name || p.title,
-          title: p.title || p.name,
-          subtitle: p.desc || p.subtitle,
-          price: p.price,
-          image: p.image,
-        };
-        const ids = [p.id, p.productId].filter(Boolean);
-        if (ids.length === 0) ids.push(pid);
-        for (const ident of ids) {
-          map[ident] = prod;
-        }
-      }
-    }
-    return map;
-  }, [
-    breakfastItems,
-    mainDishes,
-    dessertBaseItems,
-    preBowl,
-    smoothies,
-    funcionales,
-    coffees,
-    infusions,
-    sodas,
-    otherDrinks,
-    sandwichItems,
-    sandwichPriceByItem,
-  ]);
 
   const counts = useMemo(() => {
     const count = (items = []) =>
@@ -168,12 +106,7 @@ export default function App() {
     sodas,
     otherDrinks,
     dessertBaseItems,
-  ]);
-
-  function resolveProductById(id) {
-    if (!id) return null;
-    return productMap[id] || null;
-  }
+    ]);
 
   // ✅ Modo póster QR (?qr=1) – se muestra SOLO el QR
   const isQr = (() => {
@@ -202,10 +135,7 @@ export default function App() {
           <HeroHeadline />
           <SearchBar value={query} onQueryChange={setQuery} />
         </div>
-        <PromoBannerCarousel
-          items={banners}
-          resolveProductById={resolveProductById}
-        />
+        <PromoBannerCarousel />
         <ProductLists
           query={query}
           selectedCategory={selectedCategory}

--- a/src/components/PromoBannerCarousel.jsx
+++ b/src/components/PromoBannerCarousel.jsx
@@ -1,17 +1,26 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { banners as buildBanners } from "../data/banners";
+import { resolveProductById } from "../utils/resolver";
 import { useCart } from "../context/CartContext";
 import ProductQuickView from "./ProductQuickView";
-import GuideModal from "./GuideModal";
+import Portal from "./Portal";
+import { toast } from "./Toast";
 import { cop } from "../utils/money";
 
-
-export default function PromoBannerCarousel({ items = [], resolveProductById }) {
+export default function PromoBannerCarousel() {
   const { addItem } = useCart();
   const [index, setIndex] = useState(0);
   const [paused, setPaused] = useState(false);
   const [quickProduct, setQuickProduct] = useState(null);
   const [showPet, setShowPet] = useState(false);
   const startX = useRef(0);
+
+  const items = useMemo(() => {
+    return (buildBanners(import.meta.env) || []).map((item) => {
+      const product = item.productId ? resolveProductById(item.productId) : null;
+      return { ...item, product };
+    });
+  }, []);
 
   const count = items.length;
 
@@ -21,12 +30,33 @@ export default function PromoBannerCarousel({ items = [], resolveProductById }) 
     return () => clearInterval(id);
   }, [paused, count]);
 
-  const openQuickView = (product) => setQuickProduct(product);
-  const handleInfo = (action) => {
-    if (action === "modal:petfriendly") setShowPet(true);
-    else if (action === "link:reviews") {
-      const url = import.meta.env.VITE_GOOGLE_REVIEWS_URL;
-      if (url) window.open(url, "_blank", "noopener,noreferrer");
+  const handleAction = (action, product) => {
+    if (!action) return;
+    if (action === "add") {
+      if (product) {
+        addItem(product, 1);
+        toast();
+      } else {
+        toast("Producto no disponible");
+      }
+    } else if (action === "quickview") {
+      if (product) {
+        setQuickProduct(product);
+      } else {
+        toast("Producto no disponible");
+      }
+    } else if (action === "modal:petfriendly") {
+      setShowPet(true);
+    } else if (action.startsWith("link:")) {
+      const target = action.slice(5);
+      if (target === "reviews") {
+        const url = import.meta.env.VITE_GOOGLE_REVIEWS_URL;
+        if (url) window.open(url, "_blank", "noopener,noreferrer");
+      } else {
+        const key = `VITE_${target.toUpperCase()}_URL`;
+        const url = import.meta.env[key];
+        if (url) window.open(url, "_blank", "noopener,noreferrer");
+      }
     }
   };
 
@@ -34,6 +64,7 @@ export default function PromoBannerCarousel({ items = [], resolveProductById }) 
     setPaused(true);
     startX.current = e.touches[0].clientX;
   };
+
   const onTouchEnd = (e) => {
     const diff = e.changedTouches[0].clientX - startX.current;
     if (Math.abs(diff) > 40) {
@@ -56,87 +87,81 @@ export default function PromoBannerCarousel({ items = [], resolveProductById }) 
           className="flex transition-transform duration-500"
           style={{ transform: `translateX(-${index * 100}%)` }}
         >
-            {items.map((item) => {
-              const product = resolveProductById?.(item.productId) || null;
-              const price = Number(product?.price);
-              const canAdd = !!product && Number.isFinite(price) && price > 0;
-              if (import.meta.env.DEV && item.type === "product") {
-                if (!product) console.warn("Banner sin producto", item);
-                if (!canAdd) console.warn("Producto sin precio válido", product);
-              }
-              const addLabel = item.ctas?.primary?.label || "Agregar";
-              const viewLabel = item.ctas?.secondary?.label || "Ver";
-              return (
-                <div
-                  key={item.id}
-                  className="relative w-full flex-shrink-0 h-44 sm:h-56"
-                >
-                  <img
-                    src={item.image}
-                    alt={item.alt || item.title}
-                    loading="lazy"
-                    referrerPolicy="no-referrer"
-                    decoding="async"
-                    className="absolute inset-0 w-full h-full object-cover z-0"
-                  />
-                  <div className="absolute inset-0 z-10 pointer-events-none bg-gradient-to-t from-black/55 via-black/25 to-transparent" />
-                  <div className="relative z-30 pointer-events-auto flex h-full w-full flex-col justify-end p-4">
-                    <h3 className="text-white text-lg font-semibold">{item.title}</h3>
-                    {item.subtitle && (
-                      <p className="text-white/90 text-sm">{item.subtitle}</p>
-                    )}
-                    {item.type === "product" ? (
-                      <div className="mt-3 flex items-center gap-2">
+          {items.map((item) => {
+            const { product } = item;
+            const price = Number(product?.price);
+            const canAdd = !!product && Number.isFinite(price) && price > 0;
+            const addLabel = item.ctas?.primary?.label || "Agregar";
+            const viewLabel = item.ctas?.secondary?.label || "Ver";
+            return (
+              <div
+                key={item.id}
+                className="relative w-full flex-shrink-0 h-44 sm:h-56"
+              >
+                <img
+                  src={item.image}
+                  alt={item.alt || item.title}
+                  loading="lazy"
+                  referrerPolicy="no-referrer"
+                  decoding="async"
+                  className="absolute inset-0 w-full h-full object-cover z-0"
+                />
+                <div className="absolute inset-0 z-10 pointer-events-none bg-gradient-to-t from-black/55 via-black/25 to-transparent" />
+                <div className="relative z-30 pointer-events-auto flex h-full w-full flex-col justify-end p-4">
+                  <h3 className="text-white text-lg font-semibold">{item.title}</h3>
+                  {item.subtitle && (
+                    <p className="text-white/90 text-sm">{item.subtitle}</p>
+                  )}
+                  {item.type === "product" ? (
+                    <div className="mt-3 flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleAction(item.ctas?.primary?.action, product)}
+                        aria-label={addLabel}
+                        disabled={!canAdd}
+                        aria-disabled={!canAdd}
+                        className="px-3 h-8 rounded-lg bg-[#2f4131] text-white text-sm font-medium hover:bg-[#243326] focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)] disabled:bg-neutral-400 disabled:text-white/80"
+                      >
+                        {addLabel}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleAction(item.ctas?.secondary?.action, product)}
+                        aria-label={viewLabel}
+                        disabled={!product}
+                        aria-disabled={!product}
+                        className="px-3 h-8 rounded-lg bg-white/90 text-neutral-900 text-sm font-medium hover:bg-white focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)] disabled:bg-neutral-100 disabled:text-neutral-400"
+                      >
+                        {viewLabel}
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="mt-3">
+                      {item.ctas?.primary && (
                         <button
                           type="button"
-                          onClick={() => canAdd && addItem(product, 1)}
-                          aria-label={addLabel}
-                          disabled={!canAdd}
-                          aria-disabled={!canAdd}
-                          className="px-3 h-8 rounded-lg bg-[#2f4131] text-white text-sm font-medium hover:bg-[#243326] focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)] disabled:bg-neutral-400 disabled:text-white/80"
+                          onClick={() => handleAction(item.ctas.primary.action, product)}
+                          aria-label={item.ctas.primary.label || "Ver"}
+                          className="px-3 h-8 rounded-lg bg-white/90 text-neutral-900 text-sm font-medium hover:bg-white focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
                         >
-                          {addLabel}
+                          {item.ctas.primary.label || "Ver"}
                         </button>
-                        <button
-                          type="button"
-                          onClick={() => product && openQuickView(product)}
-                          aria-label={viewLabel}
-                          disabled={!product}
-                          aria-disabled={!product}
-                          className="px-3 h-8 rounded-lg bg-white/90 text-neutral-900 text-sm font-medium hover:bg-white focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)] disabled:bg-neutral-100 disabled:text-neutral-400"
-                        >
-                          {viewLabel}
-                        </button>
-                      </div>
-                    ) : (
-                      <div className="mt-3">
-                        {item.ctas?.primary && (
-                          <button
-                            type="button"
-                            onClick={() => handleInfo(item.ctas.primary.action)}
-                            aria-label={item.ctas.primary.label || "Ver"}
-                            className="px-3 h-8 rounded-lg bg-white/90 text-neutral-900 text-sm font-medium hover:bg-white focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
-                          >
-                            {item.ctas.primary.label || "Ver"}
-                          </button>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                  {item.type === "product" && canAdd && (
-                    <div
-                      aria-label="Precio"
-                      tabIndex={-1}
-                      className="absolute top-3 right-3 md:top-4 md:right-4 z-30 rounded-full px-3 py-1 text-sm bg-white/85 backdrop-blur shadow-sm text-[#2f4131] font-medium"
-                    >
-                      {cop(price)}
+                      )}
                     </div>
                   )}
                 </div>
-              );
-            })}
-
-
+                {item.type === "product" && canAdd && (
+                  <div
+                    aria-label="Precio"
+                    tabIndex={-1}
+                    className="absolute top-3 right-3 md:top-4 md:right-4 z-30 rounded-full px-3 py-1 text-sm bg-white/85 backdrop-blur shadow-sm text-[#2f4131] font-medium"
+                  >
+                    {cop(price)}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
         <div className="absolute bottom-2 md:bottom-3 left-1/2 -translate-x-1/2 z-20 pointer-events-none flex gap-2">
           {items.map((_, i) => (
@@ -157,15 +182,27 @@ export default function PromoBannerCarousel({ items = [], resolveProductById }) 
         product={quickProduct}
       />
 
-      <GuideModal open={showPet} onClose={() => setShowPet(false)}>
-        <div className="p-4 text-center">
-          <h2 className="text-base font-semibold text-[#2f4131] mb-2">Pet Friendly</h2>
-          <p className="text-sm text-neutral-700">
-            Tus mascotas son bienvenidas en Alto Andino.
-          </p>
-        </div>
-      </GuideModal>
+      <Portal>
+        {showPet && (
+          <div className="fixed inset-0 z-[80] flex items-center justify-center" role="dialog" aria-modal="true">
+            <div className="absolute inset-0 bg-black/40" onClick={() => setShowPet(false)} />
+            <div className="relative max-w-md w-[92%] rounded-2xl bg-[#FAF7F2] p-5 shadow-lg">
+              <button
+                type="button"
+                onClick={() => setShowPet(false)}
+                aria-label="Cerrar"
+                className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+              >
+                ×
+              </button>
+              <div className="p-4 text-center">
+                <h2 className="text-base font-semibold text-[#2f4131] mb-2">Pet Friendly</h2>
+                <p className="text-sm text-neutral-700">Tus mascotas son bienvenidas en Alto Andino.</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </Portal>
     </div>
   );
 }
-

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -1,0 +1,66 @@
+import {
+  breakfastItems,
+  mainDishes,
+  dessertBaseItems,
+  preBowl,
+  smoothies,
+  funcionales,
+  coffees,
+  infusions,
+  sodas,
+  otherDrinks,
+  sandwichItems,
+  sandwichPriceByItem,
+} from "../data/menuItems";
+
+const productMap = (() => {
+  const collections = [
+    breakfastItems,
+    mainDishes,
+    dessertBaseItems,
+    [preBowl],
+    smoothies,
+    funcionales,
+    coffees,
+    infusions,
+    sodas,
+    otherDrinks,
+  ];
+  if (sandwichItems && sandwichPriceByItem) {
+    const mapped = sandwichItems.map((it) => {
+      const mapping = sandwichPriceByItem[it.key];
+      const price = mapping?.unico ?? mapping?.clasico ?? mapping?.grande;
+      return { id: "sandwich:" + it.key, name: it.name, price, desc: it.desc };
+    });
+    collections.push(mapped);
+  }
+  const map = {};
+  for (const col of collections) {
+    if (!Array.isArray(col)) continue;
+    for (const p of col) {
+      const pid = p.id || p.productId;
+      if (!pid) continue;
+      const prod = {
+        ...p,
+        id: pid,
+        productId: pid,
+        name: p.name || p.title,
+        title: p.title || p.name,
+        subtitle: p.desc || p.subtitle,
+        price: p.price,
+        image: p.image,
+      };
+      const ids = [p.id, p.productId].filter(Boolean);
+      if (ids.length === 0) ids.push(pid);
+      for (const ident of ids) {
+        map[ident] = prod;
+      }
+    }
+  }
+  return map;
+})();
+
+export function resolveProductById(id) {
+  if (!id) return null;
+  return productMap[id] || null;
+}


### PR DESCRIPTION
## Summary
- Refactor promo banner carousel to load banner data internally and handle actions (add, quick view, pet modal, and links)
- Remove banner and resolver props usage in `App` component
- Add `resolveProductById` utility to centralize product lookup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adea5ee1ec83279475cc6f85f362fa