### PR TITLE
Add .env.local example for local development

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,28 @@
+# Copy this file to ".env.local" and fill in the values to configure your local environment.
+
+# Airtable record ID for the featured drink
+VITE_FEATURED_ID=
+
+# Airtable record ID for the seasonal drink
+VITE_SEASONAL_ID=
+
+# Airtable record ID for the barista's choice
+VITE_BARISTA_ID=
+
+# Optional image URL for the featured drink
+VITE_FEATURED_IMAGE_URL=
+
+# Optional image URL for the seasonal drink
+VITE_SEASONAL_IMAGE_URL=
+
+# Optional image URL for the barista's choice
+VITE_BARISTA_IMAGE_URL=
+
+# Image URL for the cocoa section background
+VITE_COCOA_IMAGE_URL=
+
+# Image URL for the reviews section background
+VITE_REVIEWS_IMAGE_URL=
+
+# Link to the café's Google Reviews page
+VITE_GOOGLE_REVIEWS_URL=


### PR DESCRIPTION
## Summary
- add `.env.local.example` with IDs and image URL variables for local setup
- include comments guiding developers to copy the file to `.env.local`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adf3ca30988327aded76fb09723a27