### PR TITLE
Ensure product banners require productId

### DIFF
--- a/src/data/banners.js
+++ b/src/data/banners.js
@@ -1,7 +1,8 @@
 export const banners = (env) => {
   const u = (k, fb) => env?.[k] || fb;
   const local = (envKey, path) => env?.[envKey] || path;
-  return [
+
+  const items = [
     {
       id: "featured",
       type: "product",
@@ -60,4 +61,15 @@ export const banners = (env) => {
       alt: "Reseñas de clientes",
     },
   ];
+
+  return items.map((banner) => {
+    if (banner.type === "product" && !banner.productId) {
+      banner.type = "info";
+      if (banner.ctas) {
+        delete banner.ctas.primary;
+        delete banner.ctas.secondary;
+      }
+    }
+    return banner;
+  });
 };


### PR DESCRIPTION
## Summary
- transform banner list before return to validate product-type banners have `productId`
- degrade product banners without `productId` to `info` type and drop primary/secondary CTAs

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adf5ff3b508327b55c21eee8fb7669