### PR TITLE
fix: contadores dinámicos por sección con búsqueda y tabs

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -1,5 +1,5 @@
 // src/components/BowlsSection.jsx
-import React, { lazy, Suspense, useState } from "react";
+import React, { lazy, Suspense, useState, useEffect } from "react";
 import clsx from "clsx";
 import { useCart } from "../context/CartContext";
 import { COP, formatCOP } from "../utils/money";
@@ -13,7 +13,7 @@ import { preBowl } from "../data/menuItems";
 // ← editar nombres y precios aquí
 const BASE_PRICE = Number(import.meta.env.VITE_BOWL_BASE_PRICE || 28000);
 
-export default function BowlsSection({ query }) {
+export default function BowlsSection({ query, onCount }) {
   const { addItem } = useCart();
   const [open, setOpen] = useState(false);
 
@@ -44,7 +44,11 @@ export default function BowlsSection({ query }) {
     { title: preBowl.name, description: preBowl.desc },
     query
   );
-  if (query && !show) return null;
+  const count = show ? 1 : 0;
+  useEffect(() => {
+    onCount?.(count);
+  }, [count, onCount]);
+  if (!count) return null;
 
   return (
     <div className="space-y-4">

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import clsx from "clsx";
 import { AddIconButton, StatusChip } from "./Buttons";
 import { toast } from "./Toast";
@@ -27,7 +27,7 @@ function findMilkDelta(milkId) {
 
 // ————————————————————————————————————————
 // Componente principal
-export default function CoffeeSection({ query }) {
+export default function CoffeeSection({ query, onCount }) {
   const cart = useCart();
 
   // Estados por ítem (diccionarios)
@@ -205,7 +205,12 @@ export default function CoffeeSection({ query }) {
   const infusionItems = (infusions || []).filter((item) =>
     matchesQuery({ title: item.name, description: item.desc }, query)
   );
-  if (!coffeeItems.length && !infusionItems.length) return null;
+  const count = coffeeItems.length + infusionItems.length;
+  useEffect(() => {
+    onCount?.(count);
+  }, [count, onCount]);
+
+  if (!count) return null;
 
   return (
     <div className="space-y-8">

--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import Section from "./Section";
+import React, { useEffect } from "react";
 import { useCart } from "../context/CartContext";
 import { AddIconButton, StatusChip } from "./Buttons";
 import { COP } from "../utils/money";
@@ -51,7 +50,7 @@ function Card({ item, onAdd }) {
   );
 }
 
-export default function ColdDrinksSection({ query, count, id }) {
+export default function ColdDrinksSection({ query, onCount }) {
   const { addItem } = useCart();
 
   const sodasFiltered = (sodas || []).filter((it) =>
@@ -60,10 +59,15 @@ export default function ColdDrinksSection({ query, count, id }) {
   const othersFiltered = (otherDrinks || []).filter((it) =>
     matchesQuery({ title: it.name, description: it.desc }, query)
   );
-  if (!sodasFiltered.length && !othersFiltered.length) return null;
+  const count = sodasFiltered.length + othersFiltered.length;
+  useEffect(() => {
+    onCount?.(count);
+  }, [count, onCount]);
+
+  if (!count) return null;
 
   return (
-    <Section title="Bebidas frías" count={count} id={id}>
+    <div>
       {sodasFiltered.length > 0 && (
         <>
           {/* Subgrupo: Gaseosas y Sodas */}
@@ -87,7 +91,7 @@ export default function ColdDrinksSection({ query, count, id }) {
           </div>
         </>
       )}
-    </Section>
+    </div>
   );
 }
 

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Chip, AddIconButton, StatusChip } from "./Buttons";
 import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
@@ -11,7 +11,7 @@ import {
   sandwichPriceByItem,
 } from "../data/menuItems";
 
-export default function Sandwiches({ query }) {
+export default function Sandwiches({ query, onCount }) {
   const cart = useCart();
   const [size, setSize] = useState("clasico"); // 'clasico' | 'grande'
 
@@ -26,6 +26,11 @@ export default function Sandwiches({ query }) {
   const filtered = items.filter((it) =>
     matchesQuery({ title: it.name, description: it.desc }, query)
   );
+
+  useEffect(() => {
+    onCount?.(filtered.length);
+  }, [filtered.length, onCount]);
+
   if (!filtered.length) return null;
 
   const priceFor = (key) => {

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { AddIconButton, StatusChip } from "./Buttons";
 import { COP } from "../utils/money";
 import { useCart } from "../context/CartContext";
@@ -54,7 +55,7 @@ function List({ items, onAdd }) {
   );
 }
 
-export default function SmoothiesSection({ query }) {
+export default function SmoothiesSection({ query, onCount }) {
   const cart = useCart();
   const add = (p) =>
     cart.addItem({
@@ -69,8 +70,12 @@ export default function SmoothiesSection({ query }) {
   const funcionalesFiltered = (funcionales || []).filter((p) =>
     matchesQuery({ title: p.name, description: p.desc }, query)
   );
+  const count = smoothiesFiltered.length + funcionalesFiltered.length;
+  useEffect(() => {
+    onCount?.(count);
+  }, [count, onCount]);
 
-  if (!smoothiesFiltered.length && !funcionalesFiltered.length) return null;
+  if (!count) return null;
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">


### PR DESCRIPTION
## Summary
- centralize section item counts in ProductLists with per-section callbacks
- report filtered counts from Sandwiches, Smoothies, Coffee, ColdDrinks and Bowls
- show message when search yields no visible products

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae053b76148327a470e74e38008cb9