### PR TITLE
feat(a11y): focus rings and ARIA improvements

### DIFF
--- a/src/components/BowlBuilder.jsx
+++ b/src/components/BowlBuilder.jsx
@@ -228,7 +228,7 @@ export default function BowlBuilder({ open, onClose }) {
           <div
             ref={modalRef}
             tabIndex={-1}
-            className="pointer-events-auto absolute inset-x-0 bottom-0 z-[110] w-full max-w-2xl max-h-[90vh] mx-auto rounded-3xl overflow-hidden bg-[#FAF7F2] shadow-2xl flex flex-col focus:outline-none"
+            className="pointer-events-auto absolute inset-x-0 bottom-0 z-[110] w-full max-w-2xl max-h-[90vh] mx-auto rounded-3xl overflow-hidden bg-[#FAF7F2] shadow-2xl flex flex-col focus-visible:outline-none"
           >
             {/* Header */}
             <div className="rounded-t-2xl bg-[#2f4131] text-white p-4">

--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -94,8 +94,8 @@ export default function BowlsSection({ query, onCount }) {
             aria-label="Armar bowl personalizado"
             className={[
               "absolute bottom-3 right-3 z-30 rounded-full bg-white text-[#2f4131] font-semibold",
-              "shadow-sm hover:bg-white/90 focus:outline-none",
-              "focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]",
+              "shadow-sm hover:bg-white/90 focus-visible:outline-none",
+              "focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
               PILL_XS,
               "sm:" + PILL_SM,
             ].join(" ")}
@@ -125,9 +125,10 @@ export default function BowlsSection({ query, onCount }) {
             "absolute bottom-4 right-4 z-20",
             unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
           )}
-          aria-label={"Añadir " + preBowl.name}
+          aria-label={"Agregar " + preBowl.name}
           onClick={handleAdd}
           aria-disabled={unavailable}
+          title={unavailable ? "No disponible" : undefined}
         />
       </div>
 

--- a/src/components/Buttons.jsx
+++ b/src/components/Buttons.jsx
@@ -13,6 +13,7 @@ export function Chip({ active, onClick, children, className = "", shape = "pill"
           ? "bg-alto-primary text-white border-alto-primary shadow"
           : "bg-white text-neutral-800 border-neutral-300 hover:border-neutral-400",
         rounded,
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
         className
       )}
     >
@@ -23,7 +24,17 @@ export function Chip({ active, onClick, children, className = "", shape = "pill"
 
 export function Button({ variant = "primary", className = "", type = "button", ...props }) {
   const base = "btn " + (variant === "primary" ? "btn-primary" : "btn-outline");
-  return <button type={type} {...props} className={base + " " + className} />;
+  return (
+    <button
+      type={type}
+      {...props}
+      className={
+        base +
+        " focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131] " +
+        className
+      }
+    />
+  );
 }
 
 // Botón de texto “Añadir” (no-FAB)
@@ -40,12 +51,12 @@ export function AddButton({
       type={type}
       disabled={disabled}
       onClick={onClick}
-      aria-label={hideText ? "Añadir" : undefined}
+      aria-label={hideText ? "Agregar" : undefined}
       className={cx(
         "inline-flex items-center justify-center gap-2 rounded-full font-semibold shadow-sm transition select-none",
         "bg-[#2f4131] text-white hover:bg-[#243326]",
         "border border-black/10",
-        "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[rgba(47,65,49,0.3)]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
         "px-3 min-w-[90px] h-9 sm:h-8 w-auto",
         "active:translate-y-[1px]",
         "disabled:bg-neutral-200 disabled:text-neutral-500 disabled:cursor-not-allowed",
@@ -86,13 +97,13 @@ export function AddIconButton({ className = "", disabled = false, variant = "sol
         "w-9 h-9 sm:w-8 sm:h-8",
         // motion & focus
         "transition will-change-transform hover:scale-105 active:scale-95",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(47,65,49,0.3)] focus-visible:ring-offset-2",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
         // disabled
-        disabled && "opacity-40 pointer-events-none",
+        disabled && "opacity-40 cursor-not-allowed",
         baseColor,
         className
       )}
-      aria-label={props["aria-label"] || "Añadir"}
+      aria-label={props["aria-label"] || "Agregar"}
     >
       <span aria-hidden className="-mt-[1px] text-xl leading-none">
         +

--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -300,7 +300,13 @@ export default function CartDrawer({ open, onClose }) {
             </span>
           </div>
           <div className="mt-3 grid grid-cols-2 gap-2">
-            <button type="button" onClick={onClose} className="h-10 rounded-xl bg-white text-neutral-900 ring-1 ring-neutral-300 hover:bg-neutral-50">Seguir pidiendo</button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="h-10 rounded-xl bg-white text-neutral-900 ring-1 ring-neutral-300 hover:bg-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+            >
+              Seguir pidiendo
+            </button>
             <a
               href={waHref}
               target="_blank"
@@ -310,7 +316,7 @@ export default function CartDrawer({ open, onClose }) {
               className={[
                 "h-10 rounded-xl grid place-items-center",
                 waHref
-                  ? "bg-[#2f4131] text-white hover:bg-[#243326] focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+                  ? "bg-[#2f4131] text-white hover:bg-[#243326] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                   : "bg-neutral-100 text-neutral-400 ring-1 ring-neutral-200 cursor-not-allowed"
               ].join(" ")}
             >

--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -30,7 +30,7 @@ export default function CategoryBar({
 }) {
   const baseItemClasses =
     variant === "chip"
-      ? "flex-none w-[100px] basis-[100px] h-[110px] snap-start rounded-xl bg-white/60 backdrop-blur-sm transition-colors transition-shadow duration-150 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,.3)] focus:ring-offset-2"
+      ? "flex-none w-[100px] basis-[100px] h-[110px] snap-start rounded-xl bg-white/60 backdrop-blur-sm transition-colors transition-shadow duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
       : "flex-none shrink-0 basis-[112px] w-[112px] h-[128px]";
   const labelHeight = variant === "chip" ? "h-[34px]" : "h-[38px]";
   const nav = (

--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -27,7 +27,7 @@ export default function CategoryTabs({
 }) {
   const tabRefs = useRef([]);
   const baseItemClasses =
-    "flex-none w-[100px] basis-[100px] h-[110px] snap-start rounded-xl bg-white/60 backdrop-blur-sm transition-colors transition-shadow duration-150 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,.3)] focus:ring-offset-2";
+    "flex-none w-[100px] basis-[100px] h-[110px] snap-start rounded-xl bg-white/60 backdrop-blur-sm transition-colors transition-shadow duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]";
 
   function focusTab(index) {
     const ref = tabRefs.current[index];

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -216,7 +216,7 @@ export default function CoffeeSection({ query, onCount }) {
     <div className="space-y-8">
       {/* CAFÉS */}
       <div>
-        <h3 className="text-sm font-semibold text-alto-primary mb-3">Cafés</h3>
+        <h3 className="text-sm font-semibold text-[#2f4131] mb-3">Cafés</h3>
         <ul className="space-y-3">
           {coffeeItems.map((item) => {
             const st = getStockState(item.id || slugify(item.name));
@@ -253,7 +253,7 @@ export default function CoffeeSection({ query, onCount }) {
                     {showAddMilk && (
                       <button
                         type="button"
-                        className="text-xs text-alto-primary underline text-left"
+                        className="text-xs text-[#2f4131] underline text-left"
                         onClick={() => toggleAddMilk(item.id)}
                       >
                         {addMilk[item.id] ? "Quitar leche" : "+ Agregar leche"}
@@ -282,10 +282,11 @@ export default function CoffeeSection({ query, onCount }) {
                 <AddIconButton
                   className={clsx(
                     "absolute bottom-4 right-4 z-20",
-                    unavailable && "opacity-40 pointer-events-none"
+                    unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
                   )}
-                  aria-label={"Añadir " + displayName(item)}
+                  aria-label={"Agregar " + displayName(item)}
                   aria-disabled={unavailable}
+                  title={unavailable ? "No disponible" : undefined}
                   onClick={handleAdd}
                 />
               </li>
@@ -296,7 +297,7 @@ export default function CoffeeSection({ query, onCount }) {
 
       {/* INFUSIONES & TÉS (incluye Chai) */}
       <div>
-        <h3 className="text-sm font-semibold text-alto-primary mb-3">
+        <h3 className="text-sm font-semibold text-[#2f4131] mb-3">
           Infusiones & Tés
         </h3>
         <ul className="space-y-3">
@@ -344,10 +345,11 @@ export default function CoffeeSection({ query, onCount }) {
                 <AddIconButton
                   className={clsx(
                     "absolute bottom-4 right-4 z-20",
-                    unavailable && "opacity-40 pointer-events-none"
+                    unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
                   )}
-                  aria-label={"Añadir " + displayName(item)}
+                  aria-label={"Agregar " + displayName(item)}
                   aria-disabled={unavailable}
+                  title={unavailable ? "No disponible" : undefined}
                   onClick={handleAdd}
                 />
               </li>

--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -42,9 +42,10 @@ function Card({ item, onAdd }) {
           "absolute bottom-2 right-2 scale-90 sm:scale-100",
           unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
         )}
-        aria-label={"Añadir " + item.name}
+        aria-label={"Agregar " + item.name}
         onClick={handleAdd}
         aria-disabled={unavailable}
+        title={unavailable ? "No disponible" : undefined}
       />
     </div>
   );

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -30,7 +30,7 @@ class ErrorBoundary extends React.Component {
           <button
             type="button"
             onClick={this.handleRetry}
-            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+            className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
           >
             Try again
           </button>

--- a/src/components/FloatingCartBar.jsx
+++ b/src/components/FloatingCartBar.jsx
@@ -31,7 +31,7 @@ export default function FloatingCartBar({ items, total, onOpen, secondaryAction,
               <button
                 type="button"
                 onClick={onOpen}
-                className="h-10 px-4 rounded-xl bg-[#2f4131] text-white hover:bg-[#243326] transition focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+                className="h-10 px-4 rounded-xl bg-[#2f4131] text-white hover:bg-[#243326] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
               >
                 Ver pedido
               </button>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -32,7 +32,7 @@ export default function Footer(){
         <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
           <a href={IG_URL} target="_blank" rel="noreferrer"
              className="inline-flex items-center gap-1.5 h-8 px-3 rounded-full text-[12px] bg-transparent hover:bg-white/10 transition
-                        focus:outline-none focus:ring-2 focus:ring-white/40"
+                        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
              style={{ color: TEXT, border: `1px solid ${BORDER}` }}
              aria-label="Abrir Instagram">
             <IconInstagram className="w-3.5 h-3.5" />
@@ -41,20 +41,20 @@ export default function Footer(){
 
           <a href={WA_LINK} target="_blank" rel="noreferrer"
              className="inline-flex items-center gap-1.5 h-8 px-3 rounded-full text-[12px] bg-transparent hover:bg-white/10 transition
-                        focus:outline-none focus:ring-2 focus:ring-white/40"
+                        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
              style={{ color: TEXT, border: `1px solid ${BORDER}` }}
              aria-label="Abrir WhatsApp">
             <IconWhatsApp className="w-3.5 h-3.5" />
             <span>WhatsApp</span>
           </a>
 
-          <a href={QR_URL} className="inline-flex items-center gap-1.5 h-8 px-3 rounded-full text-[12px] bg-transparent hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-white/40" style={{ color: TEXT, border: `1px solid ${BORDER}` }}>
+          <a href={QR_URL} className="inline-flex items-center gap-1.5 h-8 px-3 rounded-full text-[12px] bg-transparent hover:bg-white/10 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]" style={{ color: TEXT, border: `1px solid ${BORDER}` }}>
             <span>Ver póster QR</span>
           </a>
 
           <a href={REVIEWS_URL} target="_blank" rel="noreferrer"
              className="inline-flex items-center gap-1.5 h-8 px-3 rounded-full text-[12px] bg-transparent hover:bg-white/10 transition
-                        focus:outline-none focus:ring-2 focus:ring-white/40"
+                        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
              style={{ color: TEXT, border: `1px solid ${BORDER}` }}
              aria-label="Abrir reseñas">
             <IconStar className="w-3.5 h-3.5" />

--- a/src/components/GuideModal.jsx
+++ b/src/components/GuideModal.jsx
@@ -21,7 +21,7 @@ export default function GuideModal({ open, onClose, children }) {
           type="button"
           onClick={onClose}
           aria-label="Cerrar"
-          className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+          className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
         >×</button>
         {children}
       </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -30,7 +30,7 @@ export default function Header({ onCartOpen, onGuideOpen }) {
             type="button"
             onClick={handleInfoClick}
             aria-label="Información"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/10 hover:bg-white/15 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,.3)] group"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/10 hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131] group"
           >
             <Icon
               icon="material-symbols:info-outline"
@@ -41,7 +41,7 @@ export default function Header({ onCartOpen, onGuideOpen }) {
             type="button"
             onClick={() => onCartOpen?.()}
             aria-label="Abrir carrito"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/10 hover:bg-white/15 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,.3)] group"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/10 hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131] group"
           >
             <Icon
               icon="mdi:cart-outline"

--- a/src/components/HeroHeadline.jsx
+++ b/src/components/HeroHeadline.jsx
@@ -4,7 +4,7 @@ export default function HeroHeadline() {
       <h1
         id="home-headline"
         tabIndex="-1"
-        className="text-[22px] md:text-3xl font-semibold tracking-tight leading-tight focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(47,65,49,.3)] rounded"
+        className="text-[22px] md:text-3xl font-semibold tracking-tight leading-tight focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131] rounded"
         style={{
           display: "-webkit-box",
           WebkitLineClamp: 2,

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -379,6 +379,18 @@ function Desserts({ cumbre = [], base = [] }) {
               const st = getStockState(id);
               const disabled = st === "out";
               const price = cumbrePrices[s.id];
+              const handleAdd = () => {
+                if (disabled) {
+                  toast("Producto no disponible");
+                  return;
+                }
+                addItem({
+                  productId: "cumbre",
+                  name: "Cumbre Andino",
+                  price,
+                  options: { Sabor: s.label },
+                });
+              };
               return (
                 <div
                   key={s.id}
@@ -401,16 +413,10 @@ function Desserts({ cumbre = [], base = [] }) {
                   </div>
                   <AddIconButton
                     className="absolute bottom-4 right-4 z-20"
-                    aria-label={"Añadir Cumbre Andino " + s.label}
-                    onClick={() =>
-                      addItem({
-                        productId: "cumbre",
-                        name: "Cumbre Andino",
-                        price,
-                        options: { Sabor: s.label },
-                      })
-                    }
-                    disabled={disabled}
+                    aria-label={"Agregar Cumbre Andino " + s.label}
+                    onClick={handleAdd}
+                    aria-disabled={disabled}
+                    title={disabled ? "No disponible" : undefined}
                   />
                 </div>
               );
@@ -469,9 +475,10 @@ function ProductRow({ item }) {
           "absolute bottom-4 right-4 z-20",
           unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
         )}
-        aria-label={"Añadir " + item.name}
+        aria-label={"Agregar " + item.name}
         onClick={handleAdd}
         aria-disabled={unavailable}
+        title={unavailable ? "No disponible" : undefined}
       />
     </li>
   );

--- a/src/components/ProductQuickView.jsx
+++ b/src/components/ProductQuickView.jsx
@@ -66,14 +66,14 @@ export default function ProductQuickView({ open, product, onClose, onAdd }) {
         <div
           ref={modalRef}
           tabIndex={-1}
-          className="pointer-events-auto relative z-[110] mx-auto my-6 max-w-screen-sm w-[calc(100%-1.5rem)] focus:outline-none"
+          className="pointer-events-auto relative z-[110] mx-auto my-6 max-w-screen-sm w-[calc(100%-1.5rem)] focus-visible:outline-none"
         >
           <div className="relative rounded-2xl bg-white shadow-xl">
             <button
               type="button"
               onClick={() => onClose?.()}
               aria-label="Cerrar"
-              className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+              className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
             >
               ×
             </button>
@@ -97,7 +97,7 @@ export default function ProductQuickView({ open, product, onClose, onAdd }) {
                 onClick={handleAdd}
                 disabled={!canAdd}
                 aria-disabled={!canAdd}
-                className="mt-4 w-full h-10 rounded-xl bg-[#2f4131] text-white hover:bg-[#243326] focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)] disabled:bg-neutral-400 disabled:text-white/80"
+                className="mt-4 w-full h-10 rounded-xl bg-[#2f4131] text-white hover:bg-[#243326] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131] disabled:bg-neutral-400 disabled:text-white/80"
               >
                 {canAdd ? 'Agregar' : 'Producto no disponible'}
               </button>

--- a/src/components/PromoBannerCarousel.jsx
+++ b/src/components/PromoBannerCarousel.jsx
@@ -115,7 +115,7 @@ export default function PromoBannerCarousel() {
                         aria-label={addLabel}
                         disabled={!canAdd}
                         aria-disabled={!canAdd}
-                        className="px-3 h-8 rounded-lg bg-[#2f4131] text-white text-sm font-medium hover:bg-[#243326] focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)] disabled:bg-neutral-400 disabled:text-white/80"
+                        className="px-3 h-8 rounded-lg bg-[#2f4131] text-white text-sm font-medium hover:bg-[#243326] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131] disabled:bg-neutral-400 disabled:text-white/80"
                       >
                         {addLabel}
                       </button>
@@ -125,7 +125,7 @@ export default function PromoBannerCarousel() {
                         aria-label={viewLabel}
                         disabled={!product}
                         aria-disabled={!product}
-                        className="px-3 h-8 rounded-lg bg-white/90 text-neutral-900 text-sm font-medium hover:bg-white focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)] disabled:bg-neutral-100 disabled:text-neutral-400"
+                        className="px-3 h-8 rounded-lg bg-white/90 text-neutral-900 text-sm font-medium hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131] disabled:bg-neutral-100 disabled:text-neutral-400"
                       >
                         {viewLabel}
                       </button>
@@ -137,7 +137,7 @@ export default function PromoBannerCarousel() {
                           type="button"
                           onClick={() => handleAction(item.ctas.primary.action, product)}
                           aria-label={item.ctas.primary.label || "Ver"}
-                          className="px-3 h-8 rounded-lg bg-white/90 text-neutral-900 text-sm font-medium hover:bg-white focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+                          className="px-3 h-8 rounded-lg bg-white/90 text-neutral-900 text-sm font-medium hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                         >
                           {item.ctas.primary.label || "Ver"}
                         </button>
@@ -177,7 +177,7 @@ export default function PromoBannerCarousel() {
               type="button"
               onClick={() => setIndex(i)}
               aria-label={`Ir al banner ${i + 1}`}
-              className={`pointer-events-auto h-2 w-2 rounded-full ${i === index ? "bg-white/80" : "bg-white/40"} focus:outline-none focus:ring-2 focus:ring-white`}
+              className={`pointer-events-auto h-2 w-2 rounded-full ${i === index ? "bg-white/80" : "bg-white/40"} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white`}
             />
           ))}
         </div>
@@ -198,7 +198,7 @@ export default function PromoBannerCarousel() {
                 type="button"
                 onClick={() => setPetOpen(false)}
                 aria-label="Cerrar"
-                className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+                className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
               >
                 ×
               </button>

--- a/src/components/QrPoster.jsx
+++ b/src/components/QrPoster.jsx
@@ -48,14 +48,14 @@ export default function QrPoster({ url }) {
         <div className="mt-5 flex gap-2 justify-center no-print">
           <button
             type="button"
-            className="px-3 py-2 rounded-lg border bg-neutral-50 hover:bg-neutral-100 text-sm"
+            className="px-3 py-2 rounded-lg border bg-neutral-50 hover:bg-neutral-100 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
             onClick={handleCopy}
           >
             Copiar URL
           </button>
           <button
             type="button"
-            className="px-3 py-2 rounded-lg bg-alto-primary text-white hover:opacity-90 text-sm"
+            className="px-3 py-2 rounded-lg bg-alto-primary text-white hover:opacity-90 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
             onClick={handlePrint}
           >
             Imprimir

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -115,9 +115,10 @@ export default function Sandwiches({ query, onCount }) {
                     unavailable &&
                       "opacity-60 cursor-not-allowed pointer-events-auto"
                   )}
-                  aria-label={"Añadir " + it.name}
+                  aria-label={"Agregar " + it.name}
                   onClick={handleAdd}
                   aria-disabled={unavailable}
+                  title={unavailable ? "No disponible" : undefined}
                 />
               </li>
             );

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -36,7 +36,7 @@ export default function SearchBar({ value = "", onQueryChange, showChips = false
           placeholder="Buscar bowls, café, sándwich…"
           value={internal}
           onChange={handleChange}
-          className="w-full py-2 pl-9 pr-3 rounded-full border border-black/10 bg-white focus:outline-none focus:ring-2 focus:ring-[rgba(47,65,49,0.3)]"
+          className="w-full py-2 pl-9 pr-3 rounded-full border border-black/10 bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
         />
       </div>
       {showChips && (

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -44,9 +44,10 @@ function List({ items, onAdd }) {
                 "absolute bottom-4 right-4 z-20",
                 unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
               )}
-              aria-label={"Añadir " + p.name}
+              aria-label={"Agregar " + p.name}
               onClick={handleAdd}
               aria-disabled={unavailable}
+              title={unavailable ? "No disponible" : undefined}
             />
           </li>
         );
@@ -81,7 +82,7 @@ export default function SmoothiesSection({ query, onCount }) {
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
       {smoothiesFiltered.length > 0 && (
         <div>
-          <h3 className="text-sm font-semibold text-alto-primary mb-2">
+          <h3 className="text-sm font-semibold text-[#2f4131] mb-2">
             Smoothies
           </h3>
           <List items={smoothiesFiltered} onAdd={add} />
@@ -89,7 +90,7 @@ export default function SmoothiesSection({ query, onCount }) {
       )}
       {funcionalesFiltered.length > 0 && (
         <div>
-          <h3 className="text-sm font-semibold text-alto-primary mb-2">
+          <h3 className="text-sm font-semibold text-[#2f4131] mb-2">
             Funcionales
           </h3>
           <List items={funcionalesFiltered} onAdd={add} />

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -54,6 +54,7 @@ export default function Toast() {
   return (
     <div
       aria-live="polite"
+      role="status"
       className={[
         "fixed left-1/2 -translate-x-1/2 z-[120] pointer-events-none w-max",
         "transition-opacity duration-200",
@@ -66,7 +67,7 @@ export default function Toast() {
         {action && (
           <button
             type="button"
-            className="text-[11px] font-medium underline"
+            className="text-[11px] font-medium underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131] rounded"
             onClick={() => {
               action.onAction?.();
               setShow(false);


### PR DESCRIPTION
## Summary
- add consistent focus-visible rings across buttons, tabs, and links
- ensure product “+” buttons have descriptive aria labels and remain keyboard reachable
- improve toast announcements and green text contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae0902dd94832794cf287034296859