### PR TITLE
feat: product quick view on card click with image mapping

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -9,11 +9,12 @@ import { toast } from "./Toast";
 const BowlBuilder = lazy(() => import("./BowlBuilder"));
 import { getStockState, slugify, isUnavailable } from "../utils/stock";
 import { preBowl } from "../data/menuItems";
+import { getProductImage } from "../utils/images";
 
 // ← editar nombres y precios aquí
 const BASE_PRICE = Number(import.meta.env.VITE_BOWL_BASE_PRICE || 28000);
 
-export default function BowlsSection({ query, onCount }) {
+export default function BowlsSection({ query, onCount, onQuickView }) {
   const { addItem } = useCart();
   const [open, setOpen] = useState(false);
 
@@ -49,6 +50,16 @@ export default function BowlsSection({ query, onCount }) {
     onCount?.(count);
   }, [count, onCount]);
   if (!count) return null;
+
+  const product = {
+    productId: preBowl.id,
+    id: unavailable ? undefined : preBowl.id,
+    title: preBowl.name,
+    name: preBowl.name,
+    subtitle: preBowl.desc,
+    price: preBowl.price,
+    options: preBowl.options,
+  };
 
   return (
     <div className="space-y-4">
@@ -106,7 +117,24 @@ export default function BowlsSection({ query, onCount }) {
       </div>
 
       {/* Card del prearmado */}
-      <div className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => onQuickView?.(product)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onQuickView?.(product);
+          }
+        }}
+        className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+      >
+        <img
+          src={getProductImage(product)}
+          alt={preBowl.name}
+          className="w-full h-40 object-cover rounded-xl mb-3"
+          loading="lazy"
+        />
         <p className="font-semibold">{preBowl.name}</p>
         <p className="text-sm text-neutral-600">{preBowl.desc}</p>
         <div className="mt-2 flex flex-wrap gap-2">
@@ -126,7 +154,10 @@ export default function BowlsSection({ query, onCount }) {
             unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
           )}
           aria-label={"Agregar " + preBowl.name}
-          onClick={handleAdd}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleAdd();
+          }}
           aria-disabled={unavailable}
           title={unavailable ? "No disponible" : undefined}
         />

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -7,6 +7,7 @@ import { COP } from "../utils/money";
 import { getStockState, slugify, isUnavailable } from "../utils/stock";
 import { matchesQuery } from "../utils/strings";
 import { coffees, infusions } from "../data/menuItems";
+import { getProductImage } from "../utils/images";
 
 // ————————————————————————————————————————
 // Configuración de bebidas
@@ -27,7 +28,7 @@ function findMilkDelta(milkId) {
 
 // ————————————————————————————————————————
 // Componente principal
-export default function CoffeeSection({ query, onCount }) {
+export default function CoffeeSection({ query, onCount, onQuickView }) {
   const cart = useCart();
 
   // Estados por ítem (diccionarios)
@@ -231,6 +232,29 @@ export default function CoffeeSection({ query, onCount }) {
               !isAmericano;
             const hasControls =
               showAddMilk || showEspressoStyle || showMilkSelect;
+            const options = {};
+            const usesMilk =
+              item.milkPolicy === "required" ||
+              (item.milkPolicy === "optional" && addMilk[item.id]);
+            if (usesMilk) options["Leche"] = milkOf(item.id);
+            if (item.id === "cof-espresso" && addMilk[item.id]) {
+              const style = styleOf(item.id);
+              options["Estilo"] =
+                style === "mancha"
+                  ? "Macchiato"
+                  : style === "mitad"
+                  ? "Cortado"
+                  : "Con leche";
+            }
+            const product = {
+              productId: item.id,
+              id: unavailable ? undefined : item.id,
+              title: displayName(item),
+              name: displayName(item),
+              subtitle: item.desc,
+              price: finalPrice(item),
+              options,
+            };
 
             const handleAdd = () => {
               if (unavailable) {
@@ -239,12 +263,31 @@ export default function CoffeeSection({ query, onCount }) {
               }
               addToCart(item);
             };
+            const handleAddClick = (e) => {
+              e.stopPropagation();
+              handleAdd();
+            };
 
             return (
               <li
                 key={item.id}
-                className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12"
+                role="button"
+                tabIndex={0}
+                onClick={() => onQuickView?.(product)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onQuickView?.(product);
+                  }
+                }}
+                className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
               >
+                <img
+                  src={getProductImage(product)}
+                  alt={displayName(item)}
+                  className="w-full h-40 object-cover rounded-xl mb-3"
+                  loading="lazy"
+                />
                 <p className="font-semibold">{displayName(item)}</p>
                 <p className="text-xs text-neutral-600">{item.desc}</p>
                 {/* Controles contextuales */}
@@ -287,7 +330,7 @@ export default function CoffeeSection({ query, onCount }) {
                   aria-label={"Agregar " + displayName(item)}
                   aria-disabled={unavailable}
                   title={unavailable ? "No disponible" : undefined}
-                  onClick={handleAdd}
+                  onClick={handleAddClick}
                 />
               </li>
             );
@@ -306,6 +349,21 @@ export default function CoffeeSection({ query, onCount }) {
             const unavailable = st === "out" || isUnavailable(item);
             const isChai = !!item.chai;
             const showChaiMilk = isChai && modeOf(item.id) === "latte";
+            const options = {};
+            if (isChai) {
+              const mode = modeOf(item.id);
+              options["Preparación"] = mode === "latte" ? "Con leche" : "Infusión";
+              if (showChaiMilk) options["Leche"] = milkOf(item.id);
+            }
+            const product = {
+              productId: item.id,
+              id: unavailable ? undefined : item.id,
+              title: displayName(item),
+              name: displayName(item),
+              subtitle: item.desc,
+              price: finalPrice(item),
+              options,
+            };
 
             const handleAdd = () => {
               if (unavailable) {
@@ -314,12 +372,31 @@ export default function CoffeeSection({ query, onCount }) {
               }
               addToCart(item);
             };
+            const handleAddClick = (e) => {
+              e.stopPropagation();
+              handleAdd();
+            };
 
             return (
               <li
                 key={item.id}
-                className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12"
+                role="button"
+                tabIndex={0}
+                onClick={() => onQuickView?.(product)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onQuickView?.(product);
+                  }
+                }}
+                className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
               >
+                <img
+                  src={getProductImage(product)}
+                  alt={displayName(item)}
+                  className="w-full h-40 object-cover rounded-xl mb-3"
+                  loading="lazy"
+                />
                 <p className="font-semibold">{displayName(item)}</p>
                 <p className="text-xs text-neutral-600">{item.desc}</p>
                 <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2">
@@ -350,7 +427,7 @@ export default function CoffeeSection({ query, onCount }) {
                   aria-label={"Agregar " + displayName(item)}
                   aria-disabled={unavailable}
                   title={unavailable ? "No disponible" : undefined}
-                  onClick={handleAdd}
+                  onClick={handleAddClick}
                 />
               </li>
             );

--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -7,8 +7,9 @@ import { toast } from "./Toast";
 import clsx from "clsx";
 import { matchesQuery } from "../utils/strings";
 import { sodas, otherDrinks } from "../data/menuItems";
+import { getProductImage } from "../utils/images";
 
-function Card({ item, onAdd }) {
+function Card({ item, onAdd, onQuickView }) {
   const st = getStockState(item.id || slugify(item.name));
   const unavailable = st === "out" || isUnavailable(item);
   const handleAdd = () => {
@@ -24,8 +25,37 @@ function Card({ item, onAdd }) {
       qty: 1,
     });
   };
+  const handleAddClick = (e) => {
+    e.stopPropagation();
+    handleAdd();
+  };
+  const product = {
+    productId: item.id,
+    id: unavailable ? undefined : item.id,
+    title: item.name,
+    name: item.name,
+    subtitle: item.desc,
+    price: item.price,
+  };
   return (
-    <div className="relative rounded-xl bg-white ring-1 ring-neutral-200 p-3 pr-16 pb-12 min-h-[96px]">
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onQuickView?.(product)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onQuickView?.(product);
+        }
+      }}
+      className="relative rounded-xl bg-white ring-1 ring-neutral-200 p-3 pr-16 pb-12 min-h-[96px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+    >
+      <img
+        src={getProductImage(product)}
+        alt={item.name}
+        className="w-full h-40 object-cover rounded-xl mb-3"
+        loading="lazy"
+      />
       <p className="text-neutral-900 font-medium text-sm leading-tight break-words">{item.name}</p>
       {item.desc && (
         <p className="mt-0.5 text-xs text-neutral-600 leading-snug break-words">{item.desc}</p>
@@ -43,7 +73,7 @@ function Card({ item, onAdd }) {
           unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
         )}
         aria-label={"Agregar " + item.name}
-        onClick={handleAdd}
+        onClick={handleAddClick}
         aria-disabled={unavailable}
         title={unavailable ? "No disponible" : undefined}
       />
@@ -51,7 +81,7 @@ function Card({ item, onAdd }) {
   );
 }
 
-export default function ColdDrinksSection({ query, onCount }) {
+export default function ColdDrinksSection({ query, onCount, onQuickView }) {
   const { addItem } = useCart();
 
   const sodasFiltered = (sodas || []).filter((it) =>
@@ -75,7 +105,7 @@ export default function ColdDrinksSection({ query, onCount }) {
           <h3 className="text-sm font-semibold text-[#2f4131] mb-2">Gaseosas y Sodas</h3>
           <div className="grid grid-cols-2 gap-3">
             {sodasFiltered.map((it) => (
-              <Card key={it.id} item={it} onAdd={addItem} />
+              <Card key={it.id} item={it} onAdd={addItem} onQuickView={onQuickView} />
             ))}
           </div>
         </>
@@ -87,7 +117,7 @@ export default function ColdDrinksSection({ query, onCount }) {
           <h3 className="mt-5 text-sm font-semibold text-[#2f4131] mb-2">Jugos y otras bebidas frías</h3>
           <div className="grid grid-cols-2 gap-3">
             {othersFiltered.map((it) => (
-              <Card key={it.id} item={it} onAdd={addItem} />
+              <Card key={it.id} item={it} onAdd={addItem} onQuickView={onQuickView} />
             ))}
           </div>
         </>

--- a/src/components/ProductQuickView.jsx
+++ b/src/components/ProductQuickView.jsx
@@ -4,6 +4,7 @@ import { useLockBodyScroll } from '../hooks/useLockBodyScroll';
 import { useCart } from '../context/CartContext';
 import { formatCOP as cop } from '../utils/money';
 import { toast } from './Toast';
+import { getProductImage } from "../utils/images";
 
 export default function ProductQuickView({ open, product, onClose, onAdd }) {
   useLockBodyScroll(open);
@@ -42,7 +43,8 @@ export default function ProductQuickView({ open, product, onClose, onAdd }) {
 
   if (!open || !product) return null;
 
-  const { id, title, subtitle, price, image } = product;
+  const { id, title, subtitle, price } = product;
+  const image = getProductImage(product);
   const priceNum = Number(price);
   const canAdd = !!id && Number.isFinite(priceNum) && priceNum > 0;
 
@@ -77,16 +79,14 @@ export default function ProductQuickView({ open, product, onClose, onAdd }) {
             >
               ×
             </button>
-            {image && (
+            <div className="p-5">
               <img
                 src={image}
-                alt={title}
+                alt={title || product?.name || "Producto"}
                 loading="lazy"
                 decoding="async"
-                className="w-full h-48 object-cover rounded-t-2xl"
+                className="w-full h-48 object-cover rounded-xl mb-3"
               />
-            )}
-            <div className="p-5">
               <h2 className="text-lg font-semibold text-neutral-900">{title}</h2>
               {subtitle && <p className="text-sm text-neutral-600 mt-1">{subtitle}</p>}
               {Number.isFinite(priceNum) && (

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -7,8 +7,9 @@ import { toast } from "./Toast";
 import clsx from "clsx";
 import { matchesQuery } from "../utils/strings";
 import { smoothies, funcionales } from "../data/menuItems";
+import { getProductImage } from "../utils/images";
 
-function List({ items, onAdd }) {
+function List({ items, onAdd, onQuickView }) {
   return (
     <ul className="space-y-3">
       {items.map((p) => {
@@ -21,11 +22,38 @@ function List({ items, onAdd }) {
           }
           onAdd(p);
         };
+        const handleAddClick = (e) => {
+          e.stopPropagation();
+          handleAdd();
+        };
+        const product = {
+          productId: p.id || slugify(p.name),
+          id: unavailable ? undefined : p.id || slugify(p.name),
+          title: p.name,
+          name: p.name,
+          subtitle: p.desc,
+          price: p.price,
+        };
         return (
           <li
             key={p.name}
-            className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12"
+            role="button"
+            tabIndex={0}
+            onClick={() => onQuickView?.(product)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onQuickView?.(product);
+              }
+            }}
+            className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
           >
+            <img
+              src={getProductImage(product)}
+              alt={p.name}
+              className="w-full h-40 object-cover rounded-xl mb-3"
+              loading="lazy"
+            />
             <p className="font-semibold">{p.name}</p>
             <p className="text-sm text-neutral-600">{p.desc}</p>
             <div className="mt-2 flex flex-wrap gap-2">
@@ -45,7 +73,7 @@ function List({ items, onAdd }) {
                 unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
               )}
               aria-label={"Agregar " + p.name}
-              onClick={handleAdd}
+              onClick={handleAddClick}
               aria-disabled={unavailable}
               title={unavailable ? "No disponible" : undefined}
             />
@@ -56,7 +84,7 @@ function List({ items, onAdd }) {
   );
 }
 
-export default function SmoothiesSection({ query, onCount }) {
+export default function SmoothiesSection({ query, onCount, onQuickView }) {
   const cart = useCart();
   const add = (p) =>
     cart.addItem({
@@ -85,7 +113,7 @@ export default function SmoothiesSection({ query, onCount }) {
           <h3 className="text-sm font-semibold text-[#2f4131] mb-2">
             Smoothies
           </h3>
-          <List items={smoothiesFiltered} onAdd={add} />
+          <List items={smoothiesFiltered} onAdd={add} onQuickView={onQuickView} />
         </div>
       )}
       {funcionalesFiltered.length > 0 && (
@@ -93,7 +121,7 @@ export default function SmoothiesSection({ query, onCount }) {
           <h3 className="text-sm font-semibold text-[#2f4131] mb-2">
             Funcionales
           </h3>
-          <List items={funcionalesFiltered} onAdd={add} />
+          <List items={funcionalesFiltered} onAdd={add} onQuickView={onQuickView} />
         </div>
       )}
     </div>

--- a/src/data/images.js
+++ b/src/data/images.js
@@ -1,0 +1,7 @@
+// Mapa editable (luego reemplazaremos con fotos reales).
+// Clave: product.id (o productId) — Valor: URL absoluta o relativa.
+export const productImages = {
+  // "poke-hawaiano": "/images/poke-hawaiano.jpg",
+  // "salmon-andino": "/images/salmon-andino.jpg",
+  // ...
+};

--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -1,0 +1,30 @@
+// Utilidad para resolver imagen de un producto con fallback placeholder.
+import { productImages } from "../data/images";
+
+function slug(s="") {
+  return s
+    .toString()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+/** getProductImage(product)
+ * Prioridad: product.image -> productImages[id/slug] -> placeholder (picsum).
+ */
+export function getProductImage(product) {
+  const pid =
+    product?.id ||
+    product?.productId ||
+    slug(product?.name || product?.title || "producto");
+  const explicit = product?.image;
+  const mapped =
+    productImages[pid] ||
+    productImages[slug(product?.name || product?.title || "")];
+  if (explicit) return explicit;
+  if (mapped) return mapped;
+  // Placeholder determinista por semilla:
+  return `https://picsum.photos/seed/${encodeURIComponent(pid)}/640/480`;
+}


### PR DESCRIPTION
## Summary
- show a placeholder-backed image for each product via central map
- open ProductQuickView when any product card is clicked or activated with keyboard
- keep FAB add button isolated from quick view

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae0c6f173c832795606b62780bdd1c