### PR TITLE
feat(story): modal pet friendly con tabs e historias de productos

### DIFF
--- a/src/components/PetFriendlyModal.jsx
+++ b/src/components/PetFriendlyModal.jsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import Portal from "./Portal";
+import { cocoa } from "../data/petFriendly";
+
+export default function PetFriendlyModal({ open, onClose }) {
+  const [tab, setTab] = useState("cocoa");
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  if (!open) return null;
+
+  const tabs = [
+    { id: "cocoa", label: "Cocoa" },
+    { id: "philosophy", label: "Filosofía" },
+    { id: "gallery", label: "Galería" },
+  ];
+
+  return (
+    <Portal>
+      <div className="fixed inset-0 z-[80] flex items-center justify-center" role="dialog" aria-modal="true">
+        <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+        <div className="relative max-w-lg w-[92%] max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-5 dark:bg-neutral-900 dark:text-neutral-100">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Cerrar"
+            className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+          >
+            ×
+          </button>
+          <div className="mb-4" role="tablist">
+            {tabs.map((t) => (
+              <button
+                key={t.id}
+                id={`tab-${t.id}`}
+                role="tab"
+                aria-selected={tab === t.id}
+                aria-controls={`panel-${t.id}`}
+                onClick={() => setTab(t.id)}
+                className={`mr-2 mb-2 px-3 py-1 text-sm font-medium rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131] ${
+                  tab === t.id
+                    ? "bg-[#2f4131] text-white"
+                    : "bg-black/5 text-neutral-700 hover:bg-black/10"
+                }`}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+          {tab === "cocoa" && (
+            <div id="panel-cocoa" role="tabpanel" aria-labelledby="tab-cocoa">
+              <img
+                src={cocoa.hero}
+                alt={cocoa.name}
+                loading="lazy"
+                className="w-full h-auto rounded-lg"
+              />
+              <p className="mt-3 text-sm text-center">Conoce a {cocoa.name}, nuestra pitbull bonsái.</p>
+            </div>
+          )}
+          {tab === "philosophy" && (
+            <div id="panel-philosophy" role="tabpanel" aria-labelledby="tab-philosophy">
+              <p className="text-sm whitespace-pre-line">{cocoa.philosophy}</p>
+            </div>
+          )}
+          {tab === "gallery" && (
+            <div
+              id="panel-gallery"
+              role="tabpanel"
+              aria-labelledby="tab-gallery"
+              className="grid grid-cols-2 sm:grid-cols-3 gap-2"
+            >
+              {cocoa.gallery.map((img, i) => (
+                <img
+                  key={i}
+                  src={img.src}
+                  alt={img.alt}
+                  loading="lazy"
+                  className="w-full h-auto rounded-lg object-cover"
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/src/components/StoryModal.jsx
+++ b/src/components/StoryModal.jsx
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import Portal from "./Portal";
+
+export default function StoryModal({ open, onClose, story }) {
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  if (!open || !story) return null;
+
+  return (
+    <Portal>
+      <div className="fixed inset-0 z-[80] flex items-center justify-center" role="dialog" aria-modal="true">
+        <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+        <div className="relative max-w-lg w-[92%] max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-5 dark:bg-neutral-900 dark:text-neutral-100">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Cerrar"
+            className="absolute top-3 right-3 h-8 w-8 grid place-items-center rounded-full bg-black/5 hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+          >
+            ×
+          </button>
+          <h2 className="text-lg font-semibold mb-4">{story.title}</h2>
+          {story.sections?.map((sec, i) => (
+            <div key={i} className="mb-4 last:mb-0">
+              {sec.image && (
+                <img
+                  src={sec.image}
+                  alt={sec.heading}
+                  loading="lazy"
+                  className="w-full h-auto rounded-md mb-2"
+                />
+              )}
+              {sec.heading && (
+                <h3 className="text-base font-medium mb-1">{sec.heading}</h3>
+              )}
+              {sec.body && (
+                <p className="text-sm whitespace-pre-line">{sec.body}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/src/data/petFriendly.js
+++ b/src/data/petFriendly.js
@@ -1,0 +1,13 @@
+export const cocoa = {
+  name: "Cocoa",
+  hero: import.meta.env.VITE_COCOA_IMAGE_URL || "https://picsum.photos/seed/cocoa/1024/600",
+  philosophy: "Somos Pet Friendly: respeto, cuidado y bienestar animal...",
+  gallery: [
+    {
+      src: import.meta.env.VITE_COCOA_IMAGE_URL || "https://picsum.photos/seed/cocoa1/800/600",
+      alt: "Cocoa 1",
+    },
+    { src: "https://picsum.photos/seed/cocoa2/800/600", alt: "Cocoa 2" },
+    { src: "https://picsum.photos/seed/cocoa3/800/600", alt: "Cocoa 3" },
+  ],
+};

--- a/src/data/stories.js
+++ b/src/data/stories.js
@@ -1,0 +1,48 @@
+// Historias/recetas por productId. Usa IDs reales si existen; placeholder si no.
+const FEAT = import.meta.env.VITE_FEATURED_ID;
+const SEAS = import.meta.env.VITE_SEASONAL_ID;
+const BAR = import.meta.env.VITE_BARISTA_ID;
+
+export const productStories = {
+  // Ejemplo para producto destacado
+  [FEAT || "featured-placeholder"]: {
+    title: "Origen y sabor — Producto del día",
+    sections: [
+      {
+        heading: "Nuestra historia",
+        image: "https://picsum.photos/seed/story1/960/540",
+        body: "Este plato nace de ingredientes frescos de productores locales...",
+      },
+      {
+        heading: "Curiosidades",
+        image: null,
+        body: "• Marida bien con bebidas frías cítricas.\n• Ideal como post-entreno.",
+      },
+      {
+        heading: "Receta (en casa)",
+        image: "https://picsum.photos/seed/recipe1/960/540",
+        body: "1) Cocina la base...\n2) Adiciona toppings...\n3) Sirve con salsa al gusto.",
+      },
+    ],
+  },
+  [SEAS || "seasonal-placeholder"]: {
+    title: "Temporada — Sabores que vuelven",
+    sections: [
+      {
+        heading: "Ingredientes de temporada",
+        image: "https://picsum.photos/seed/season1/960/540",
+        body: "Usamos fruta de cosecha...",
+      },
+    ],
+  },
+  [BAR || "barista-placeholder"]: {
+    title: "Barista Recomendado",
+    sections: [
+      {
+        heading: "Perfil de taza",
+        image: "https://picsum.photos/seed/coffee1/960/540",
+        body: "Notas a cacao, panela y frutos rojos.",
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- add Cocoa pet-friendly modal with tabs for info, philosophy and gallery
- add generic story/recipe modal and local story data
- hook PromoBannerCarousel CTAs to open pet-friendly or product story modals

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae0cf27448832798499763e7a58535