### PR TITLE
feat: vertical category chips and static header

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -109,7 +109,7 @@ export default function CategoryBar({
   }, [categories, manualSelectAt, selected, onSelect]);
 
   return (
-    <div className="sticky top-0 z-40 bg-transparent backdrop-blur-[2px] border-b border-black/5 dark:border-white/10 dark:bg-neutral-900 dark:text-neutral-100">
+    <div className="sticky top-0 z-40 bg-transparent backdrop-blur-[2px] border-b border-black/5 dark:border-white/10">
       <div className="relative">
         <div
           role="tablist"
@@ -133,18 +133,18 @@ export default function CategoryBar({
                 onKeyDown={handleKey}
                 onClick={() => handleSelect(cat.id, idx)}
                 className={clsx(
-                  "inline-flex items-center gap-2 snap-start rounded-2xl px-3 min-w-[96px] h-14",
+                  "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-20 h-20 px-2",
                   "bg-white/12 backdrop-blur-md border border-white/20 shadow-[0_4px_16px_rgba(0,0,0,0.08)]",
                   "text-neutral-800 dark:text-neutral-100",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
-                  active && "bg-white/28 border-white/40 ring-2 ring-[#2f4131]/50",
+                  active && "ring-2 ring-[#2f4131]/50 bg-white/28 border-white/40",
                   "hover:bg-white/20 hover:border-white/30"
                 )}
               >
                 <span className="w-10 h-10 rounded-full grid place-items-center shrink-0 bg-white/20 border border-white/30">
                   <IconWithFallback id={cat.id} className="w-6 h-6 object-contain" />
                 </span>
-                <span className="text-sm font-medium line-clamp-2 text-left">
+                <span className="mt-1 text-xs font-medium leading-tight whitespace-normal break-words line-clamp-2">
                   {cat.label}
                 </span>
               </button>

--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -1,45 +1,8 @@
-function labelDe(slug) {
-  const labels = {
-    todos: "Todos",
-    desayunos: "Desayunos",
-    bowls: "Bowls",
-    platos: "Platos Fuertes",
-    sandwiches: "Sándwiches",
-    smoothies: "Smoothies & Funcionales",
-    cafe: "Café de especialidad",
-    bebidasfrias: "Bebidas frías",
-    postres: "Postres",
-  };
-  return labels[slug] || "";
-}
-
-export default function CategoryHeader({
-  selectedCategory = "todos",
-  visibleCount = 0,
-}) {
-  const label = labelDe(selectedCategory);
-  const showHint = selectedCategory === "todos";
+export default function CategoryHeader() {
   return (
-    <section
-      aria-labelledby="cat-title"
-      className="px-4 md:px-6 mt-3 md:mt-4 mb-2 md:mb-3"
-    >
-      <h2
-        id="cat-title"
-        className="text-lg md:text-xl font-semibold tracking-tight text-[#2f4131]"
-      >
-        {label}
-        {selectedCategory !== "todos" && (
-          <span className="ml-2 text-sm text-zinc-500 font-medium align-middle">
-            ({visibleCount})
-          </span>
-        )}
-      </h2>
-      {showHint && (
-        <p className="text-sm md:text-[15px] text-zinc-600">
-          Elige una categoría o desliza para ver más →
-        </p>
-      )}
+    <section className="px-4 pt-3 pb-1 bg-transparent">
+      <h2 className="text-lg font-semibold">Categorías</h2>
+      <p className="text-sm text-neutral-600">Elige una categoría o desliza para ver más →</p>
     </section>
   );
 }

--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -97,7 +97,7 @@ export default function CategoryTabs({
   }, [items, manualSelectAt, selected, onChange]);
 
   return (
-    <div className="sticky top-0 z-40 bg-transparent backdrop-blur-[2px] border-b border-black/5 dark:border-white/10 dark:bg-neutral-900 dark:text-neutral-100">
+    <div className="sticky top-0 z-40 bg-transparent backdrop-blur-[2px] border-b border-black/5 dark:border-white/10">
       <div className="relative">
         <div
           role="tablist"
@@ -121,18 +121,18 @@ export default function CategoryTabs({
                 onKeyDown={handleKey}
                 onClick={() => handleSelect(item.id, idx)}
                 className={clsx(
-                  "inline-flex items-center gap-2 snap-start rounded-2xl px-3 min-w-[96px] h-14",
+                  "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-20 h-20 px-2",
                   "bg-white/12 backdrop-blur-md border border-white/20 shadow-[0_4px_16px_rgba(0,0,0,0.08)]",
                   "text-neutral-800 dark:text-neutral-100",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
-                  active && "bg-white/28 border-white/40 ring-2 ring-[#2f4131]/50",
+                  active && "ring-2 ring-[#2f4131]/50 bg-white/28 border-white/40",
                   "hover:bg-white/20 hover:border-white/30"
                 )}
               >
                 <span className="w-10 h-10 rounded-full grid place-items-center shrink-0 bg-white/20 border border-white/30">
                   <IconWithFallback icon={item.icon} className="w-6 h-6 object-contain" />
                 </span>
-                <span className="text-sm font-medium line-clamp-2 text-left">
+                <span className="mt-1 text-xs font-medium leading-tight whitespace-normal break-words line-clamp-2">
                   {item.label}
                 </span>
               </button>

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -45,7 +45,6 @@ export default function ProductLists({
   const setCount = useCallback((id, n) => {
     setCounts((prev) => (prev[id] === n ? prev : { ...prev, [id]: n }));
   }, []);
-  const visibleCount = counts[selectedCategory] || 0;
   const categories = useMemo(
     () => [
       { id: "desayunos", label: "Desayunos", tintClass: "bg-amber-50" },
@@ -376,37 +375,30 @@ export default function ProductLists({
 
   return (
     <>
-      <div className="mx-auto max-w-screen-md sticky top-0 z-40 bg-white border-b">
-        {!featureTabs && (
-          <CategoryHeader
-            selectedCategory={selectedCategory}
-            visibleCount={visibleCount}
-          />
-        )}
-        {featureTabs ? (
-          <CategoryTabs
-            items={tabItems}
-            value={selectedCategory}
-            onChange={(slug) => {
-              if (slug === "todos") {
-                handleManualSelect({ id: "todos" });
-              } else {
-                const cat = categories.find((c) => c.id === slug);
-                handleManualSelect(cat ?? { id: "todos" });
-              }
-            }}
-            featureTabs={featureTabs}
-          />
-        ) : (
-          <CategoryBar
-            categories={[{ id: "todos", label: "Todos", tintClass: "bg-stone-100" }, ...categories]}
-            activeId={selectedCategory}
-            onSelect={(cat) => handleManualSelect(cat)}
-            variant="chip"
-            featureTabs={featureTabs}
-          />
-        )}
-      </div>
+      {!featureTabs && <CategoryHeader />}
+      {featureTabs ? (
+        <CategoryTabs
+          items={tabItems}
+          value={selectedCategory}
+          onChange={(slug) => {
+            if (slug === "todos") {
+              handleManualSelect({ id: "todos" });
+            } else {
+              const cat = categories.find((c) => c.id === slug);
+              handleManualSelect(cat ?? { id: "todos" });
+            }
+          }}
+          featureTabs={featureTabs}
+        />
+      ) : (
+        <CategoryBar
+          categories={[{ id: "todos", label: "Todos", tintClass: "bg-stone-100" }, ...categories]}
+          activeId={selectedCategory}
+          onSelect={(cat) => handleManualSelect(cat)}
+          variant="chip"
+          featureTabs={featureTabs}
+        />
+      )}
       {query && !Object.values(counts).some((n) => n > 0) && (
         <p className="text-sm text-neutral-600 px-4">
           No hay resultados para “{query}”.


### PR DESCRIPTION
## Summary
- redesign category bar and tabs with transparent sticky wrapper and vertical chips
- replace dynamic category header with static title and subtitle
- remove enclosing white container from product lists to allow full-bleed bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae1504867c8327b11e544f893940b4