### PR TITLE
feat(cards): layout media-left con thumbnail y FAB + quick view por card click; thumbnails en carrito usando getProductImage

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -1,10 +1,9 @@
 // src/components/BowlsSection.jsx
 import React, { lazy, Suspense, useState, useEffect } from "react";
-import clsx from "clsx";
 import { useCart } from "../context/CartContext";
-import { COP, formatCOP } from "../utils/money";
+import { formatCOP } from "../utils/money";
 import { matchesQuery } from "../utils/strings";
-import { AddIconButton, StatusChip, PILL_XS, PILL_SM } from "./Buttons";
+import { StatusChip, PILL_XS, PILL_SM } from "./Buttons";
 import { toast } from "./Toast";
 const BowlBuilder = lazy(() => import("./BowlBuilder"));
 import { getStockState, slugify, isUnavailable } from "../utils/stock";
@@ -117,7 +116,7 @@ export default function BowlsSection({ query, onCount, onQuickView }) {
       </div>
 
       {/* Card del prearmado */}
-      <div
+      <article
         role="button"
         tabIndex={0}
         onClick={() => onQuickView?.(product)}
@@ -127,41 +126,48 @@ export default function BowlsSection({ query, onCount, onQuickView }) {
             onQuickView?.(product);
           }
         }}
-        className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+        aria-disabled={unavailable}
+        className="group grid grid-cols-[96px_1fr] gap-3 p-3 sm:p-4 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
       >
         <img
           src={getProductImage(product)}
           alt={preBowl.name}
-          className="w-full h-40 object-cover rounded-xl mb-3"
           loading="lazy"
+          className="w-24 h-24 rounded-xl object-cover"
         />
-        <p className="font-semibold">{preBowl.name}</p>
-        <p className="text-sm text-neutral-600">{preBowl.desc}</p>
-        <div className="mt-2 flex flex-wrap gap-2">
-          {st === "low" && (
-            <StatusChip variant="low">Pocas unidades</StatusChip>
-          )}
-          {unavailable && (
-            <StatusChip variant="soldout">No Disponible</StatusChip>
-          )}
+        <div className="min-w-0 flex flex-col">
+          <h3 className="text-base font-semibold truncate">{preBowl.name}</h3>
+          <p className="text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2 mt-0.5">{preBowl.desc}</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {st === "low" && (
+              <StatusChip variant="low">Pocas unidades</StatusChip>
+            )}
+            {unavailable && (
+              <StatusChip variant="soldout">No Disponible</StatusChip>
+            )}
+          </div>
+          <div className="mt-auto flex items-end justify-between gap-3 pt-2">
+            <div>
+              <div className="text-base font-semibold">{formatCOP(preBowl.price)}</div>
+            </div>
+            <button
+              type="button"
+              aria-label={`Agregar ${preBowl.name}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (unavailable) {
+                  toast("Producto no disponible");
+                  return;
+                }
+                handleAdd();
+              }}
+              className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+            >
+              +
+            </button>
+          </div>
         </div>
-        <div className="absolute top-5 right-5 z-10 text-neutral-800 font-bold">
-          ${COP(preBowl.price)}
-        </div>
-        <AddIconButton
-          className={clsx(
-            "absolute bottom-4 right-4 z-20",
-            unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
-          )}
-          aria-label={"Agregar " + preBowl.name}
-          onClick={(e) => {
-            e.stopPropagation();
-            handleAdd();
-          }}
-          aria-disabled={unavailable}
-          title={unavailable ? "No disponible" : undefined}
-        />
-      </div>
+      </article>
 
       {/* Modal de armado */}
       {open && (

--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -3,6 +3,7 @@ import { useCart } from "../context/CartContext";
 import SwipeRevealItem from "./SwipeRevealItem";
 import Portal from "./Portal";
 import { toast } from "./Toast";
+import { getProductImage } from "../utils/images";
 
 const toNumberCOP = (v) => {
   if (typeof v === "number") return v;
@@ -212,16 +213,14 @@ export default function CartDrawer({ open, onClose }) {
 
               <div className="p-3 bg-white rounded-xl ring-1 ring-neutral-200">
                 <div className="flex items-start gap-3">
-                  {/* imagen opcional */}
-                  {it.image ? (
-                    <img
-                      src={it.image}
-                      alt={it.name}
-                      loading="lazy"
-                      decoding="async"
-                      className="h-12 w-12 rounded-lg object-cover ring-1 ring-neutral-200"
-                    />
-                  ) : null}
+                  <img
+                    src={getProductImage(it)}
+                    alt=""
+                    aria-hidden="true"
+                    loading="lazy"
+                    decoding="async"
+                    className="w-12 h-12 rounded-md object-cover"
+                  />
 
                   <div className="flex-1 min-w-0">
                     <div className="flex items-start justify-between gap-2">

--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -1,10 +1,9 @@
 import React, { useEffect } from "react";
 import { useCart } from "../context/CartContext";
-import { AddIconButton, StatusChip } from "./Buttons";
-import { COP } from "../utils/money";
+import { StatusChip } from "./Buttons";
+import { formatCOP } from "../utils/money";
 import { getStockState, slugify, isUnavailable } from "../utils/stock";
 import { toast } from "./Toast";
-import clsx from "clsx";
 import { matchesQuery } from "../utils/strings";
 import { sodas, otherDrinks } from "../data/menuItems";
 import { getProductImage } from "../utils/images";
@@ -21,12 +20,16 @@ function Card({ item, onAdd, onQuickView }) {
       productId: item.id,
       name: item.name,
       price: item.price,
-      priceFmt: "$" + COP(item.price),
+      priceFmt: formatCOP(item.price),
       qty: 1,
     });
   };
   const handleAddClick = (e) => {
     e.stopPropagation();
+    if (unavailable) {
+      toast("Producto no disponible");
+      return;
+    }
     handleAdd();
   };
   const product = {
@@ -38,7 +41,7 @@ function Card({ item, onAdd, onQuickView }) {
     price: item.price,
   };
   return (
-    <div
+    <article
       role="button"
       tabIndex={0}
       onClick={() => onQuickView?.(product)}
@@ -48,36 +51,39 @@ function Card({ item, onAdd, onQuickView }) {
           onQuickView?.(product);
         }
       }}
-      className="relative rounded-xl bg-white ring-1 ring-neutral-200 p-3 pr-16 pb-12 min-h-[96px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+      aria-disabled={unavailable}
+      className="group grid grid-cols-[96px_1fr] gap-3 p-3 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
     >
       <img
         src={getProductImage(product)}
         alt={item.name}
-        className="w-full h-40 object-cover rounded-xl mb-3"
         loading="lazy"
+        className="w-24 h-24 rounded-xl object-cover"
       />
-      <p className="text-neutral-900 font-medium text-sm leading-tight break-words">{item.name}</p>
-      {item.desc && (
-        <p className="mt-0.5 text-xs text-neutral-600 leading-snug break-words">{item.desc}</p>
-      )}
-      <div className="mt-2 flex flex-wrap gap-2">
-        {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
-        {unavailable && <StatusChip variant="soldout">No Disponible</StatusChip>}
-      </div>
-      <div className="absolute top-2 right-2 min-w-[64px] text-right text-neutral-900 font-semibold text-sm">
-        {"$" + COP(item.price)}
-      </div>
-      <AddIconButton
-        className={clsx(
-          "absolute bottom-2 right-2 scale-90 sm:scale-100",
-          unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
+      <div className="min-w-0 flex flex-col">
+        <h3 className="text-sm font-semibold truncate">{item.name}</h3>
+        {item.desc && (
+          <p className="mt-0.5 text-xs text-neutral-600 dark:text-neutral-300 line-clamp-2">{item.desc}</p>
         )}
-        aria-label={"Agregar " + item.name}
-        onClick={handleAddClick}
-        aria-disabled={unavailable}
-        title={unavailable ? "No disponible" : undefined}
-      />
-    </div>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
+          {unavailable && <StatusChip variant="soldout">No Disponible</StatusChip>}
+        </div>
+        <div className="mt-auto flex items-end justify-between gap-3 pt-2">
+          <div>
+            <div className="text-sm font-semibold">{formatCOP(item.price)}</div>
+          </div>
+          <button
+            type="button"
+            aria-label={`Agregar ${item.name}`}
+            onClick={handleAddClick}
+            className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+          >
+            +
+          </button>
+        </div>
+      </div>
+    </article>
   );
 }
 

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -1,11 +1,10 @@
 import { useMemo, useEffect, useCallback, useState, cloneElement, useRef } from "react";
 import { useCart } from "../context/CartContext";
-import { COP } from "../utils/money";
+import { formatCOP } from "../utils/money";
 import { getStockState, slugify, isUnavailable } from "../utils/stock";
 import { toast } from "./Toast";
-import clsx from "clsx";
 import { matchesQuery } from "../utils/strings";
-import { AddIconButton, StatusChip } from "./Buttons";
+import { StatusChip } from "./Buttons";
 import Section from "./Section";
 import Sandwiches from "./Sandwiches";
 import SmoothiesSection from "./SmoothiesSection";
@@ -453,46 +452,73 @@ function Desserts({ cumbre = [], base = [], onQuickView }) {
               const st = getStockState(id);
               const disabled = st === "out";
               const price = cumbrePrices[s.id];
-              const handleAdd = () => {
-                if (disabled) {
-                  toast("Producto no disponible");
-                  return;
-                }
-                addItem({
-                  productId: "cumbre",
-                  name: "Cumbre Andino",
-                  price,
-                  options: { Sabor: s.label },
-                });
+              const product = {
+                productId: "cumbre",
+                id: disabled ? undefined : id,
+                title: "Cumbre Andino",
+                name: "Cumbre Andino",
+                subtitle: s.label,
+                price,
+                options: { Sabor: s.label },
               };
               return (
-                <div
+                <article
                   key={s.id}
-                  className={
-                    "relative rounded-xl border border-neutral-200/60 bg-white p-4 sm:p-5 pr-20 pb-12 " +
-                    (disabled ? "opacity-60" : "")
-                  }
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => onQuickView?.(product)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onQuickView?.(product);
+                    }
+                  }}
+                  aria-disabled={disabled}
+                  className="group grid grid-cols-[96px_1fr] gap-3 p-3 rounded-2xl border border-neutral-200/60 bg-white shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                 >
-                  <p className="text-sm">{s.label}</p>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    {st === "low" && (
-                      <StatusChip variant="low">Pocas unidades</StatusChip>
-                    )}
-                    {st === "out" && (
-                      <StatusChip variant="soldout">No Disponible</StatusChip>
-                    )}
-                  </div>
-                  <div className="absolute top-5 right-5 z-10 text-neutral-800 font-semibold">
-                    ${COP(price)}
-                  </div>
-                  <AddIconButton
-                    className="absolute bottom-4 right-4 z-20"
-                    aria-label={"Agregar Cumbre Andino " + s.label}
-                    onClick={handleAdd}
-                    aria-disabled={disabled}
-                    title={disabled ? "No disponible" : undefined}
+                  <img
+                    src={getProductImage(product)}
+                    alt={"Cumbre Andino"}
+                    loading="lazy"
+                    className="w-24 h-24 rounded-xl object-cover"
                   />
-                </div>
+                  <div className="min-w-0 flex flex-col">
+                    <h3 className="text-base font-semibold truncate">{s.label}</h3>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {st === "low" && (
+                        <StatusChip variant="low">Pocas unidades</StatusChip>
+                      )}
+                      {st === "out" && (
+                        <StatusChip variant="soldout">No Disponible</StatusChip>
+                      )}
+                    </div>
+                    <div className="mt-auto flex items-end justify-between gap-3 pt-2">
+                      <div>
+                        <div className="text-base font-semibold">{formatCOP(price)}</div>
+                      </div>
+                      <button
+                        type="button"
+                        aria-label={`Agregar Cumbre Andino ${s.label}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (disabled) {
+                            toast("Producto no disponible");
+                            return;
+                          }
+                          addItem({
+                            productId: "cumbre",
+                            name: "Cumbre Andino",
+                            price,
+                            options: { Sabor: s.label },
+                          });
+                        }}
+                        className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                      >
+                        +
+                      </button>
+                    </div>
+                  </div>
+                </article>
               );
             })}
           </div>
@@ -520,21 +546,11 @@ function List({ items, onQuickView }) {
   );
 }
 
+
 function ProductRow({ item, onQuickView }) {
   const { addItem } = useCart();
   const st = getStockState(item.id || slugify(item.name));
   const unavailable = st === "out" || isUnavailable(item);
-  const handleAdd = () => {
-    if (unavailable) {
-      toast("Producto no disponible");
-      return;
-    }
-    addItem({ productId: item.id, name: item.name, price: item.price });
-  };
-  const handleAddClick = (e) => {
-    e.stopPropagation();
-    handleAdd();
-  };
   const product = {
     productId: item.id,
     id: unavailable ? undefined : item.id,
@@ -544,7 +560,7 @@ function ProductRow({ item, onQuickView }) {
     price: item.price,
   };
   return (
-    <li
+    <article
       role="button"
       tabIndex={0}
       onClick={() => onQuickView?.(product)}
@@ -554,35 +570,49 @@ function ProductRow({ item, onQuickView }) {
           onQuickView?.(product);
         }
       }}
-      className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+      aria-disabled={unavailable}
+      className="group grid grid-cols-[96px_1fr] gap-3 p-3 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
     >
       <img
         src={getProductImage(product)}
         alt={item.name || "Producto"}
-        className="w-full h-40 object-cover rounded-xl mb-3"
         loading="lazy"
+        className="w-24 h-24 rounded-xl object-cover"
       />
-      <p className="font-semibold">{item.name}</p>
-      <p className="text-xs text-neutral-600 mt-1">{item.desc}</p>
-      <div className="mt-2 flex flex-wrap gap-2">
-        {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
-        {unavailable && (
-          <StatusChip variant="soldout">No Disponible</StatusChip>
+      <div className="min-w-0 flex flex-col">
+        <h3 className="text-base font-semibold truncate">{item.name}</h3>
+        {item.desc && (
+          <p className="text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2 mt-0.5">
+            {item.desc}
+          </p>
         )}
+        <div className="mt-2 flex flex-wrap gap-2">
+          {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
+          {unavailable && <StatusChip variant="soldout">No Disponible</StatusChip>}
+        </div>
+        <div className="mt-auto flex items-end justify-between gap-3 pt-2">
+          <div>
+            <div className="text-base font-semibold">
+              {typeof item.price === "number" ? formatCOP(item.price) : item.price}
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label={`Agregar ${item.name || "producto"}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (unavailable) {
+                toast("Producto no disponible");
+                return;
+              }
+              addItem({ productId: item.id, name: item.name, price: item.price });
+            }}
+            className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+          >
+            +
+          </button>
+        </div>
       </div>
-      <div className="absolute top-5 right-5 z-10 text-neutral-800 font-semibold">
-        ${COP(item.price)}
-      </div>
-      <AddIconButton
-        className={clsx(
-          "absolute bottom-4 right-4 z-20",
-          unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
-        )}
-        aria-label={"Agregar " + item.name}
-        onClick={handleAddClick}
-        aria-disabled={unavailable}
-        title={unavailable ? "No disponible" : undefined}
-      />
-    </li>
+    </article>
   );
 }

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from "react";
-import { Chip, AddIconButton, StatusChip } from "./Buttons";
-import { COP } from "../utils/money";
+import { Chip, StatusChip } from "./Buttons";
+import { formatCOP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 import { getStockState, isUnavailable } from "../utils/stock";
 import { toast } from "./Toast";
-import clsx from "clsx";
 import { matchesQuery } from "../utils/strings";
 import {
   sandwichItems,
@@ -133,12 +132,8 @@ export default function Sandwiches({ query, onCount, onQuickView }) {
               }
               add(it);
             };
-            const handleAddClick = (e) => {
-              e.stopPropagation();
-              handleAdd();
-            };
             return (
-              <li
+              <article
                 key={it.key}
                 role="button"
                 tabIndex={0}
@@ -149,52 +144,56 @@ export default function Sandwiches({ query, onCount, onQuickView }) {
                     onQuickView?.(product);
                   }
                 }}
-                className={clsx(
-                  "relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
-                )}
+                aria-disabled={unavailable}
+                className="group grid grid-cols-[96px_1fr] gap-3 p-3 sm:p-4 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
               >
                 <img
                   src={getProductImage(product)}
                   alt={it.name}
-                  className="w-full h-40 object-cover rounded-xl mb-3"
                   loading="lazy"
+                  className="w-24 h-24 rounded-xl object-cover"
                 />
-                <p className="font-semibold">{renderWithEmoji(it.name)}</p>
-                <p className="text-sm text-neutral-600">
-                  {renderWithEmoji(it.desc)}
-                </p>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {st === "low" && (
-                    <StatusChip variant="low">Pocas unidades</StatusChip>
-                  )}
-                  {unavailable && (
-                    <StatusChip variant="soldout">No Disponible</StatusChip>
-                  )}
-                  {priceByItem[it.key].unico && (
-                    <StatusChip variant="neutral">Precio único</StatusChip>
-                  )}
+                <div className="min-w-0 flex flex-col">
+                  <h3 className="text-base font-semibold truncate">{renderWithEmoji(it.name)}</h3>
+                  <p className="text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2 mt-0.5">
+                    {renderWithEmoji(it.desc)}
+                  </p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {st === "low" && (
+                      <StatusChip variant="low">Pocas unidades</StatusChip>
+                    )}
+                    {unavailable && (
+                      <StatusChip variant="soldout">No Disponible</StatusChip>
+                    )}
+                    {priceByItem[it.key].unico && (
+                      <StatusChip variant="neutral">Precio único</StatusChip>
+                    )}
+                  </div>
+                  <div className="mt-auto flex items-end justify-between gap-3 pt-2">
+                    <div>
+                      <div className="text-base font-semibold">
+                        {formatCOP(price)}
+                      </div>
+                      {!priceByItem[it.key].unico && (
+                        <div className="text-xs text-neutral-500">
+                          Mostrando precio de {size === "clasico" ? "Clásico" : "Grande"}
+                        </div>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      aria-label={`Agregar ${it.name}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleAdd();
+                      }}
+                      className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                    >
+                      +
+                    </button>
+                  </div>
                 </div>
-                <div className="absolute top-5 right-5 z-10 text-neutral-800 font-semibold text-right">
-                  ${COP(price)}
-                  {!priceByItem[it.key].unico && (
-                    <span className="block text-xs text-neutral-500">
-                      Mostrando precio de {size === "clasico" ? "Clásico" : "Grande"}
-                    </span>
-                  )}
-                </div>
-                <AddIconButton
-                  className={clsx(
-                    "absolute bottom-4 right-4 z-20",
-                    unavailable &&
-                      "opacity-60 cursor-not-allowed pointer-events-auto"
-                  )}
-                  aria-label={"Agregar " + it.name}
-                  onClick={handleAddClick}
-                  aria-disabled={unavailable}
-                  title={unavailable ? "No disponible" : undefined}
-                />
-              </li>
+              </article>
             );
           })}
         </ul>

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -1,10 +1,9 @@
 import { useEffect } from "react";
-import { AddIconButton, StatusChip } from "./Buttons";
-import { COP } from "../utils/money";
+import { StatusChip } from "./Buttons";
+import { formatCOP } from "../utils/money";
 import { useCart } from "../context/CartContext";
 import { getStockState, slugify, isUnavailable } from "../utils/stock";
 import { toast } from "./Toast";
-import clsx from "clsx";
 import { matchesQuery } from "../utils/strings";
 import { smoothies, funcionales } from "../data/menuItems";
 import { getProductImage } from "../utils/images";
@@ -15,17 +14,6 @@ function List({ items, onAdd, onQuickView }) {
       {items.map((p) => {
         const st = getStockState(p.id || slugify(p.name));
         const unavailable = st === "out" || isUnavailable(p);
-        const handleAdd = () => {
-          if (unavailable) {
-            toast("Producto no disponible");
-            return;
-          }
-          onAdd(p);
-        };
-        const handleAddClick = (e) => {
-          e.stopPropagation();
-          handleAdd();
-        };
         const product = {
           productId: p.id || slugify(p.name),
           id: unavailable ? undefined : p.id || slugify(p.name),
@@ -35,7 +23,7 @@ function List({ items, onAdd, onQuickView }) {
           price: p.price,
         };
         return (
-          <li
+          <article
             key={p.name}
             role="button"
             tabIndex={0}
@@ -46,38 +34,46 @@ function List({ items, onAdd, onQuickView }) {
                 onQuickView?.(product);
               }
             }}
-            className="relative rounded-2xl p-5 sm:p-6 shadow-sm bg-white pr-20 pb-12 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+            aria-disabled={unavailable}
+            className="group grid grid-cols-[96px_1fr] gap-3 p-3 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
           >
             <img
               src={getProductImage(product)}
               alt={p.name}
-              className="w-full h-40 object-cover rounded-xl mb-3"
               loading="lazy"
+              className="w-24 h-24 rounded-xl object-cover"
             />
-            <p className="font-semibold">{p.name}</p>
-            <p className="text-sm text-neutral-600">{p.desc}</p>
-            <div className="mt-2 flex flex-wrap gap-2">
-              {st === "low" && (
-                <StatusChip variant="low">Pocas unidades</StatusChip>
+            <div className="min-w-0 flex flex-col">
+              <h3 className="text-base font-semibold truncate">{p.name}</h3>
+              {p.desc && (
+                <p className="text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2 mt-0.5">{p.desc}</p>
               )}
-              {unavailable && (
-                <StatusChip variant="soldout">No Disponible</StatusChip>
-              )}
+              <div className="mt-2 flex flex-wrap gap-2">
+                {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
+                {unavailable && <StatusChip variant="soldout">No Disponible</StatusChip>}
+              </div>
+              <div className="mt-auto flex items-end justify-between gap-3 pt-2">
+                <div>
+                  <div className="text-base font-semibold">{formatCOP(p.price)}</div>
+                </div>
+                <button
+                  type="button"
+                  aria-label={`Agregar ${p.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (unavailable) {
+                      toast("Producto no disponible");
+                      return;
+                    }
+                    onAdd(p);
+                  }}
+                  className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                >
+                  +
+                </button>
+              </div>
             </div>
-            <div className="absolute top-5 right-5 z-10 text-neutral-800 font-semibold">
-              ${COP(p.price)}
-            </div>
-            <AddIconButton
-              className={clsx(
-                "absolute bottom-4 right-4 z-20",
-                unavailable && "opacity-60 cursor-not-allowed pointer-events-auto"
-              )}
-              aria-label={"Agregar " + p.name}
-              onClick={handleAddClick}
-              aria-disabled={unavailable}
-              title={unavailable ? "No disponible" : undefined}
-            />
-          </li>
+          </article>
         );
       })}
     </ul>

--- a/src/data/images.js
+++ b/src/data/images.js
@@ -1,7 +1,5 @@
-// Mapa editable (luego reemplazaremos con fotos reales).
-// Clave: product.id (o productId) — Valor: URL absoluta o relativa.
 export const productImages = {
-  // "poke-hawaiano": "/images/poke-hawaiano.jpg",
-  // "salmon-andino": "/images/salmon-andino.jpg",
-  // ...
+  // Reemplaza estos ejemplos con tus URLs reales en /public/images/...
+  // "sandwich-cerdo": "/images/sandwich-cerdo.webp",
+  // "cumbre-energetica": "/images/cumbre-energetica.webp",
 };

--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -1,7 +1,6 @@
 // Utilidad para resolver imagen de un producto con fallback placeholder.
 import { productImages } from "../data/images";
-
-function slug(s="") {
+function slug(s = "") {
   return s
     .toString()
     .toLowerCase()
@@ -10,21 +9,14 @@ function slug(s="") {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");
 }
-
-/** getProductImage(product)
- * Prioridad: product.image -> productImages[id/slug] -> placeholder (picsum).
- */
 export function getProductImage(product) {
-  const pid =
-    product?.id ||
-    product?.productId ||
-    slug(product?.name || product?.title || "producto");
-  const explicit = product?.image;
+  const pid = product?.id || slug(product?.name || product?.title || "producto");
+  if (product?.image) return product.image;
   const mapped =
     productImages[pid] ||
     productImages[slug(product?.name || product?.title || "")];
-  if (explicit) return explicit;
-  if (mapped) return mapped;
-  // Placeholder determinista por semilla:
-  return `https://picsum.photos/seed/${encodeURIComponent(pid)}/640/480`;
+  return (
+    mapped ||
+    `https://picsum.photos/seed/${encodeURIComponent(pid)}/640/640`
+  );
 }


### PR DESCRIPTION
## Summary
- redesign product cards to media-left layout with image thumbnails and quick view on card click
- show product thumbnails in cart using `getProductImage`

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68ae13913cd88327aa6aae8c6802df22