### PR TITLE
fix(category-bar): fondo transparente real y chips en dos líneas

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -110,49 +110,47 @@ export default function CategoryBar({
 
   return (
     <div className="sticky top-0 z-40 bg-transparent backdrop-blur-[2px] border-b border-black/5 dark:border-white/10">
-      <div className="relative">
-        <div
-          role="tablist"
-          className="-mx-4 px-4 py-2 flex gap-3 md:gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory scrollbar-none"
-          onWheel={(e) => {
-            if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
-              e.currentTarget.scrollLeft += e.deltaY;
-            }
-          }}
-          ref={railRef}
-        >
-          {categories.map((cat, idx) => {
-            const active = selected === cat.id;
-            return (
-              <button
-                key={cat.id}
-                role="tab"
-                aria-selected={active}
-                aria-controls={`section-${cat.id}`}
-                tabIndex={active ? 0 : -1}
-                onKeyDown={handleKey}
-                onClick={() => handleSelect(cat.id, idx)}
-                className={clsx(
-                  "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-20 h-20 px-2",
-                  "bg-white/12 backdrop-blur-md border border-white/20 shadow-[0_4px_16px_rgba(0,0,0,0.08)]",
-                  "text-neutral-800 dark:text-neutral-100",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
-                  active && "ring-2 ring-[#2f4131]/50 bg-white/28 border-white/40",
-                  "hover:bg-white/20 hover:border-white/30"
-                )}
-              >
-                <span className="w-10 h-10 rounded-full grid place-items-center shrink-0 bg-white/20 border border-white/30">
-                  <IconWithFallback id={cat.id} className="w-6 h-6 object-contain" />
-                </span>
-                <span className="mt-1 text-xs font-medium leading-tight whitespace-normal break-words line-clamp-2">
-                  {cat.label}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-        <div className="pointer-events-none absolute left-0 top-0 h-full w-6 bg-gradient-to-r from-[var(--app-bg,#efe7dd)] to-transparent dark:from-neutral-900" />
-        <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-[var(--app-bg,#efe7dd)] to-transparent dark:from-neutral-900" />
+      <div
+        role="tablist"
+        className="-mx-4 px-4 py-2 flex gap-3 md:gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory scrollbar-none relative"
+        onWheel={(e) => {
+          if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+            e.currentTarget.scrollLeft += e.deltaY;
+          }
+        }}
+        ref={railRef}
+      >
+        {categories.map((cat, idx) => {
+          const active = selected === cat.id;
+          return (
+            <button
+              key={cat.id}
+              role="tab"
+              aria-selected={active}
+              aria-controls={`section-${cat.id}`}
+              tabIndex={active ? 0 : -1}
+              onKeyDown={handleKey}
+              onClick={() => handleSelect(cat.id, idx)}
+              className={clsx(
+                "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-24 md:w-28 h-20 px-2",
+                "bg-white/12 backdrop-blur-md border border-white/20 shadow-[0_4px_16px_rgba(0,0,0,0.08)]",
+                "text-neutral-800 dark:text-neutral-100",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
+                "hover:bg-white/20 hover:border-white/30",
+                "aria-selected:bg-white/28 aria-selected:border-white/40"
+              )}
+            >
+              <span className="w-10 h-10 rounded-full grid place-items-center shrink-0 bg-white/20 border border-white/30">
+                <IconWithFallback id={cat.id} className="w-6 h-6 object-contain" />
+              </span>
+              <span className="mt-1 text-xs font-medium leading-tight whitespace-normal break-words line-clamp-2">
+                {cat.label}
+              </span>
+            </button>
+          );
+        })}
+        <div className="pointer-events-none absolute left-0 top-0 h-full w-6 bg-gradient-to-r from-[#efe7dd] to-transparent dark:from-neutral-900" />
+        <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-[#efe7dd] to-transparent dark:from-neutral-900" />
       </div>
     </div>
   );

--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -1,8 +1,10 @@
 export default function CategoryHeader() {
   return (
-    <section className="px-4 pt-3 pb-1 bg-transparent">
-      <h2 className="text-lg font-semibold">Categorías</h2>
-      <p className="text-sm text-neutral-600">Elige una categoría o desliza para ver más →</p>
-    </section>
+    <>
+      <h2 className="px-4 pt-3 pb-1 text-lg font-semibold">Categorías</h2>
+      <p className="px-4 text-sm text-neutral-600">
+        Elige una categoría o desliza para ver más →
+      </p>
+    </>
   );
 }

--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -98,49 +98,47 @@ export default function CategoryTabs({
 
   return (
     <div className="sticky top-0 z-40 bg-transparent backdrop-blur-[2px] border-b border-black/5 dark:border-white/10">
-      <div className="relative">
-        <div
-          role="tablist"
-          className="-mx-4 px-4 py-2 flex gap-3 md:gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory scrollbar-none"
-          onWheel={(e) => {
-            if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
-              e.currentTarget.scrollLeft += e.deltaY;
-            }
-          }}
-          ref={railRef}
-        >
-          {items.map((item, idx) => {
-            const active = selected === item.id;
-            return (
-              <button
-                key={item.id}
-                role="tab"
-                aria-selected={active}
-                aria-controls={`panel-${item.id}`}
-                tabIndex={active ? 0 : -1}
-                onKeyDown={handleKey}
-                onClick={() => handleSelect(item.id, idx)}
-                className={clsx(
-                  "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-20 h-20 px-2",
-                  "bg-white/12 backdrop-blur-md border border-white/20 shadow-[0_4px_16px_rgba(0,0,0,0.08)]",
-                  "text-neutral-800 dark:text-neutral-100",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
-                  active && "ring-2 ring-[#2f4131]/50 bg-white/28 border-white/40",
-                  "hover:bg-white/20 hover:border-white/30"
-                )}
-              >
-                <span className="w-10 h-10 rounded-full grid place-items-center shrink-0 bg-white/20 border border-white/30">
-                  <IconWithFallback icon={item.icon} className="w-6 h-6 object-contain" />
-                </span>
-                <span className="mt-1 text-xs font-medium leading-tight whitespace-normal break-words line-clamp-2">
-                  {item.label}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-        <div className="pointer-events-none absolute left-0 top-0 h-full w-6 bg-gradient-to-r from-[var(--app-bg,#efe7dd)] to-transparent dark:from-neutral-900" />
-        <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-[var(--app-bg,#efe7dd)] to-transparent dark:from-neutral-900" />
+      <div
+        role="tablist"
+        className="-mx-4 px-4 py-2 flex gap-3 md:gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory scrollbar-none relative"
+        onWheel={(e) => {
+          if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+            e.currentTarget.scrollLeft += e.deltaY;
+          }
+        }}
+        ref={railRef}
+      >
+        {items.map((item, idx) => {
+          const active = selected === item.id;
+          return (
+            <button
+              key={item.id}
+              role="tab"
+              aria-selected={active}
+              aria-controls={`panel-${item.id}`}
+              tabIndex={active ? 0 : -1}
+              onKeyDown={handleKey}
+              onClick={() => handleSelect(item.id, idx)}
+              className={clsx(
+                "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-24 md:w-28 h-20 px-2",
+                "bg-white/12 backdrop-blur-md border border-white/20 shadow-[0_4px_16px_rgba(0,0,0,0.08)]",
+                "text-neutral-800 dark:text-neutral-100",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
+                "hover:bg-white/20 hover:border-white/30",
+                "aria-selected:bg-white/28 aria-selected:border-white/40"
+              )}
+            >
+              <span className="w-10 h-10 rounded-full grid place-items-center shrink-0 bg-white/20 border border-white/30">
+                <IconWithFallback icon={item.icon} className="w-6 h-6 object-contain" />
+              </span>
+              <span className="mt-1 text-xs font-medium leading-tight whitespace-normal break-words line-clamp-2">
+                {item.label}
+              </span>
+            </button>
+          );
+        })}
+        <div className="pointer-events-none absolute left-0 top-0 h-full w-6 bg-gradient-to-r from-[#efe7dd] to-transparent dark:from-neutral-900" />
+        <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-[#efe7dd] to-transparent dark:from-neutral-900" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove dark backgrounds from category bar and tabs, using transparent wrapper
- replace lateral fades with beige gradients
- widen category chips with vertical layout and 2-line labels
- simplify category header markup without extra background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae175201148327b65cb3c745bb2089