### PR TITLE
style(ui): unify category tabs and product cards

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -127,17 +127,17 @@ export default function BowlsSection({ query, onCount, onQuickView }) {
           }
         }}
         aria-disabled={unavailable}
-        className="group grid grid-cols-[96px_1fr] gap-3 p-3 sm:p-4 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+        className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
       >
         <img
           src={getProductImage(product)}
           alt={preBowl.name}
           loading="lazy"
-          className="w-24 h-24 rounded-xl object-cover"
+          className="w-24 h-24 md:w-28 md:h-28 rounded-xl object-cover"
         />
         <div className="min-w-0 flex flex-col">
-          <h3 className="text-base font-semibold truncate">{preBowl.name}</h3>
-          <p className="text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2 mt-0.5">{preBowl.desc}</p>
+          <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{preBowl.name}</h3>
+          <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{preBowl.desc}</p>
           <div className="mt-2 flex flex-wrap gap-2">
             {st === "low" && (
               <StatusChip variant="low">Pocas unidades</StatusChip>
@@ -148,7 +148,7 @@ export default function BowlsSection({ query, onCount, onQuickView }) {
           </div>
           <div className="mt-auto flex items-end justify-between gap-3 pt-2">
             <div>
-              <div className="text-base font-semibold">{formatCOP(preBowl.price)}</div>
+              <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">{formatCOP(preBowl.price)}</div>
             </div>
             <button
               type="button"
@@ -161,7 +161,7 @@ export default function BowlsSection({ query, onCount, onQuickView }) {
                 }
                 handleAdd();
               }}
-              className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+              className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
             >
               +
             </button>

--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -132,25 +132,24 @@ export default function CategoryBar({
               onKeyDown={handleKey}
               onClick={() => handleSelect(cat.id, idx)}
               className={clsx(
-                "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-24 md:w-28 h-20 px-2",
-                "bg-white/12 backdrop-blur-md border border-white/20 shadow-[0_4px_16px_rgba(0,0,0,0.08)]",
-                "text-neutral-800 dark:text-neutral-100",
+                "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-24 md:w-28 h-24 px-2",
+                "bg-white/30 backdrop-blur-md border border-black/10 dark:border-white/15",
+                "text-neutral-900 dark:text-neutral-50",
+                "shadow-[0_1px_0_rgba(0,0,0,0.02),0_8px_16px_-6px_rgba(0,0,0,0.12)]",
+                "hover:bg-white/40",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
-                "hover:bg-white/20 hover:border-white/30",
-                "aria-selected:bg-white/28 aria-selected:border-white/40"
+                active && "ring-2 ring-[#2f4131]/60 bg-white/50 border-black/10 dark:border-white/25"
               )}
             >
-              <span className="w-10 h-10 rounded-full grid place-items-center shrink-0 bg-white/20 border border-white/30">
-                <IconWithFallback id={cat.id} className="w-6 h-6 object-contain" />
+              <span className="w-12 h-12 rounded-full grid place-items-center shrink-0 bg-white/60 border border-white/70">
+                <IconWithFallback id={cat.id} className="w-7 h-7 object-contain" />
               </span>
-              <span className="mt-1 text-xs font-medium leading-tight whitespace-normal break-words line-clamp-2">
+              <span className="mt-1 text-sm font-semibold leading-tight text-neutral-900 dark:text-neutral-50 whitespace-normal break-words line-clamp-2">
                 {cat.label}
               </span>
             </button>
           );
         })}
-        <div className="pointer-events-none absolute left-0 top-0 h-full w-6 bg-gradient-to-r from-[#efe7dd] to-transparent dark:from-neutral-900" />
-        <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-[#efe7dd] to-transparent dark:from-neutral-900" />
       </div>
     </div>
   );

--- a/src/components/CategoryHeader.jsx
+++ b/src/components/CategoryHeader.jsx
@@ -1,10 +1,10 @@
 export default function CategoryHeader() {
   return (
-    <>
-      <h2 className="px-4 pt-3 pb-1 text-lg font-semibold">Categorías</h2>
-      <p className="px-4 text-sm text-neutral-600">
+    <div className="px-4 pt-3 pb-1 bg-transparent">
+      <h2 className="text-lg font-semibold">Categorías</h2>
+      <p className="text-sm text-neutral-600">
         Elige una categoría o desliza para ver más →
       </p>
-    </>
+    </div>
   );
 }

--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -120,25 +120,24 @@ export default function CategoryTabs({
               onKeyDown={handleKey}
               onClick={() => handleSelect(item.id, idx)}
               className={clsx(
-                "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-24 md:w-28 h-20 px-2",
-                "bg-white/12 backdrop-blur-md border border-white/20 shadow-[0_4px_16px_rgba(0,0,0,0.08)]",
-                "text-neutral-800 dark:text-neutral-100",
+                "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-24 md:w-28 h-24 px-2",
+                "bg-white/30 backdrop-blur-md border border-black/10 dark:border-white/15",
+                "text-neutral-900 dark:text-neutral-50",
+                "shadow-[0_1px_0_rgba(0,0,0,0.02),0_8px_16px_-6px_rgba(0,0,0,0.12)]",
+                "hover:bg-white/40",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
-                "hover:bg-white/20 hover:border-white/30",
-                "aria-selected:bg-white/28 aria-selected:border-white/40"
+                active && "ring-2 ring-[#2f4131]/60 bg-white/50 border-black/10 dark:border-white/25"
               )}
             >
-              <span className="w-10 h-10 rounded-full grid place-items-center shrink-0 bg-white/20 border border-white/30">
-                <IconWithFallback icon={item.icon} className="w-6 h-6 object-contain" />
+              <span className="w-12 h-12 rounded-full grid place-items-center shrink-0 bg-white/60 border border-white/70">
+                <IconWithFallback icon={item.icon} className="w-7 h-7 object-contain" />
               </span>
-              <span className="mt-1 text-xs font-medium leading-tight whitespace-normal break-words line-clamp-2">
+              <span className="mt-1 text-sm font-semibold leading-tight text-neutral-900 dark:text-neutral-50 whitespace-normal break-words line-clamp-2">
                 {item.label}
               </span>
             </button>
           );
         })}
-        <div className="pointer-events-none absolute left-0 top-0 h-full w-6 bg-gradient-to-r from-[#efe7dd] to-transparent dark:from-neutral-900" />
-        <div className="pointer-events-none absolute right-0 top-0 h-full w-6 bg-gradient-to-l from-[#efe7dd] to-transparent dark:from-neutral-900" />
       </div>
     </div>
   );

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -268,11 +268,11 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
               handleAdd();
             };
 
-            return (
-              <article
-                key={item.id}
-                role="button"
-                tabIndex={0}
+              return (
+                <article
+                  key={item.id}
+                  role="button"
+                  tabIndex={0}
                 onClick={() => onQuickView?.(product)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
@@ -281,19 +281,21 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
                   }
                 }}
                 aria-disabled={unavailable}
-                className="group grid grid-cols-[96px_1fr] gap-3 p-3 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
-              >
-                <img
-                  src={getProductImage(product)}
-                  alt={displayName(item)}
-                  loading="lazy"
-                  className="w-24 h-24 rounded-xl object-cover"
-                />
-                <div className="min-w-0 flex flex-col">
-                  <h3 className="text-base font-semibold truncate">{displayName(item)}</h3>
-                  <p className="text-xs text-neutral-600 dark:text-neutral-300 line-clamp-2 mt-0.5">{item.desc}</p>
-                  {hasControls && (
-                    <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2">
+                  className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                >
+                  <img
+                    src={getProductImage(product)}
+                    alt={displayName(item)}
+                    loading="lazy"
+                    className="w-24 h-24 md:w-28 md:h-28 rounded-xl object-cover"
+                  />
+                  <div className="min-w-0 flex flex-col">
+                    <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">
+                      {displayName(item)}
+                    </h3>
+                    <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{item.desc}</p>
+                    {hasControls && (
+                      <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2">
                       {showAddMilk && (
                         <button
                           type="button"
@@ -320,30 +322,32 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
                       <StatusChip variant="soldout">No Disponible</StatusChip>
                     )}
                   </div>
-                  <div className="mt-auto flex items-end justify-between gap-3 pt-2">
-                    <div>
-                      <div className="text-base font-semibold">{formatCOP(finalPrice(item))}</div>
+                    <div className="mt-auto flex items-end justify-between gap-3 pt-2">
+                      <div>
+                        <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">
+                          {formatCOP(finalPrice(item))}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        aria-label={`Agregar ${displayName(item)}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (unavailable) {
+                            toast("Producto no disponible");
+                            return;
+                          }
+                          addToCart(item);
+                        }}
+                        className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                      >
+                        +
+                      </button>
                     </div>
-                    <button
-                      type="button"
-                      aria-label={`Agregar ${displayName(item)}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (unavailable) {
-                          toast("Producto no disponible");
-                          return;
-                        }
-                        addToCart(item);
-                      }}
-                      className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
-                    >
-                      +
-                    </button>
                   </div>
-                </div>
-              </article>
-            );
-          })}
+                </article>
+              );
+            })}
         </ul>
       </div>
 
@@ -399,17 +403,17 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
                   }
                 }}
                 aria-disabled={unavailable}
-                className="group grid grid-cols-[96px_1fr] gap-3 p-3 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
               >
                 <img
                   src={getProductImage(product)}
                   alt={displayName(item)}
                   loading="lazy"
-                  className="w-24 h-24 rounded-xl object-cover"
+                  className="w-24 h-24 md:w-28 md:h-28 rounded-xl object-cover"
                 />
                 <div className="min-w-0 flex flex-col">
-                  <h3 className="text-base font-semibold truncate">{displayName(item)}</h3>
-                  <p className="text-xs text-neutral-600 dark:text-neutral-300 line-clamp-2 mt-0.5">{item.desc}</p>
+                  <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{displayName(item)}</h3>
+                  <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{item.desc}</p>
                   <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2">
                     {isChai && <ChaiModeSelect id={item.id} />}
                     {showChaiMilk && (
@@ -429,7 +433,7 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
                   </div>
                   <div className="mt-auto flex items-end justify-between gap-3 pt-2">
                     <div>
-                      <div className="text-base font-semibold">{formatCOP(finalPrice(item))}</div>
+                      <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">{formatCOP(finalPrice(item))}</div>
                     </div>
                     <button
                       type="button"
@@ -442,7 +446,7 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
                         }
                         addToCart(item);
                       }}
-                      className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                      className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                     >
                       +
                     </button>

--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -52,18 +52,18 @@ function Card({ item, onAdd, onQuickView }) {
         }
       }}
       aria-disabled={unavailable}
-      className="group grid grid-cols-[96px_1fr] gap-3 p-3 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+      className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
     >
       <img
         src={getProductImage(product)}
         alt={item.name}
         loading="lazy"
-        className="w-24 h-24 rounded-xl object-cover"
+        className="w-24 h-24 md:w-28 md:h-28 rounded-xl object-cover"
       />
       <div className="min-w-0 flex flex-col">
-        <h3 className="text-sm font-semibold truncate">{item.name}</h3>
+        <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{item.name}</h3>
         {item.desc && (
-          <p className="mt-0.5 text-xs text-neutral-600 dark:text-neutral-300 line-clamp-2">{item.desc}</p>
+          <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{item.desc}</p>
         )}
         <div className="mt-2 flex flex-wrap gap-2">
           {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
@@ -71,13 +71,13 @@ function Card({ item, onAdd, onQuickView }) {
         </div>
         <div className="mt-auto flex items-end justify-between gap-3 pt-2">
           <div>
-            <div className="text-sm font-semibold">{formatCOP(item.price)}</div>
+            <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">{formatCOP(item.price)}</div>
           </div>
           <button
             type="button"
             aria-label={`Agregar ${item.name}`}
             onClick={handleAddClick}
-            className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+            className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
           >
             +
           </button>

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -466,16 +466,16 @@ function Desserts({ cumbre = [], base = [], onQuickView }) {
                     }
                   }}
                   aria-disabled={disabled}
-                  className="group grid grid-cols-[96px_1fr] gap-3 p-3 rounded-2xl border border-neutral-200/60 bg-white shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                  className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                 >
                   <img
                     src={getProductImage(product)}
                     alt={"Cumbre Andino"}
                     loading="lazy"
-                    className="w-24 h-24 rounded-xl object-cover"
+                    className="w-24 h-24 md:w-28 md:h-28 rounded-xl object-cover"
                   />
                   <div className="min-w-0 flex flex-col">
-                    <h3 className="text-base font-semibold truncate">{s.label}</h3>
+                    <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{s.label}</h3>
                     <div className="mt-2 flex flex-wrap gap-2">
                       {st === "low" && (
                         <StatusChip variant="low">Pocas unidades</StatusChip>
@@ -486,7 +486,7 @@ function Desserts({ cumbre = [], base = [], onQuickView }) {
                     </div>
                     <div className="mt-auto flex items-end justify-between gap-3 pt-2">
                       <div>
-                        <div className="text-base font-semibold">{formatCOP(price)}</div>
+                        <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">{formatCOP(price)}</div>
                       </div>
                       <button
                         type="button"
@@ -504,7 +504,7 @@ function Desserts({ cumbre = [], base = [], onQuickView }) {
                             options: { Sabor: s.label },
                           });
                         }}
-                        className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                        className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                       >
                         +
                       </button>
@@ -563,20 +563,18 @@ function ProductRow({ item, onQuickView }) {
         }
       }}
       aria-disabled={unavailable}
-      className="group grid grid-cols-[96px_1fr] gap-3 p-3 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+      className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
     >
       <img
         src={getProductImage(product)}
         alt={item.name || "Producto"}
         loading="lazy"
-        className="w-24 h-24 rounded-xl object-cover"
+        className="w-24 h-24 md:w-28 md:h-28 rounded-xl object-cover"
       />
       <div className="min-w-0 flex flex-col">
-        <h3 className="text-base font-semibold truncate">{item.name}</h3>
+        <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{item.name}</h3>
         {item.desc && (
-          <p className="text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2 mt-0.5">
-            {item.desc}
-          </p>
+          <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{item.desc}</p>
         )}
         <div className="mt-2 flex flex-wrap gap-2">
           {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
@@ -584,7 +582,7 @@ function ProductRow({ item, onQuickView }) {
         </div>
         <div className="mt-auto flex items-end justify-between gap-3 pt-2">
           <div>
-            <div className="text-base font-semibold">
+            <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">
               {typeof item.price === "number" ? formatCOP(item.price) : item.price}
             </div>
           </div>
@@ -599,7 +597,7 @@ function ProductRow({ item, onQuickView }) {
               }
               addItem({ productId: item.id, name: item.name, price: item.price });
             }}
-            className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+            className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
           >
             +
           </button>

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -145,17 +145,19 @@ export default function Sandwiches({ query, onCount, onQuickView }) {
                   }
                 }}
                 aria-disabled={unavailable}
-                className="group grid grid-cols-[96px_1fr] gap-3 p-3 sm:p-4 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
               >
                 <img
                   src={getProductImage(product)}
                   alt={it.name}
                   loading="lazy"
-                  className="w-24 h-24 rounded-xl object-cover"
+                  className="w-24 h-24 md:w-28 md:h-28 rounded-xl object-cover"
                 />
                 <div className="min-w-0 flex flex-col">
-                  <h3 className="text-base font-semibold truncate">{renderWithEmoji(it.name)}</h3>
-                  <p className="text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2 mt-0.5">
+                  <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">
+                    {renderWithEmoji(it.name)}
+                  </h3>
+                  <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">
                     {renderWithEmoji(it.desc)}
                   </p>
                   <div className="mt-2 flex flex-wrap gap-2">
@@ -171,7 +173,7 @@ export default function Sandwiches({ query, onCount, onQuickView }) {
                   </div>
                   <div className="mt-auto flex items-end justify-between gap-3 pt-2">
                     <div>
-                      <div className="text-base font-semibold">
+                      <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">
                         {formatCOP(price)}
                       </div>
                       {!priceByItem[it.key].unico && (
@@ -187,7 +189,7 @@ export default function Sandwiches({ query, onCount, onQuickView }) {
                         e.stopPropagation();
                         handleAdd();
                       }}
-                      className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                      className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                     >
                       +
                     </button>

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -35,18 +35,18 @@ function List({ items, onAdd, onQuickView }) {
               }
             }}
             aria-disabled={unavailable}
-            className="group grid grid-cols-[96px_1fr] gap-3 p-3 rounded-2xl bg-white/70 dark:bg-neutral-900/70 border border-black/5 dark:border-white/10 shadow-sm hover:shadow-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+            className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
           >
             <img
               src={getProductImage(product)}
               alt={p.name}
               loading="lazy"
-              className="w-24 h-24 rounded-xl object-cover"
+              className="w-24 h-24 md:w-28 md:h-28 rounded-xl object-cover"
             />
             <div className="min-w-0 flex flex-col">
-              <h3 className="text-base font-semibold truncate">{p.name}</h3>
+              <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{p.name}</h3>
               {p.desc && (
-                <p className="text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2 mt-0.5">{p.desc}</p>
+                <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{p.desc}</p>
               )}
               <div className="mt-2 flex flex-wrap gap-2">
                 {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
@@ -54,7 +54,9 @@ function List({ items, onAdd, onQuickView }) {
               </div>
               <div className="mt-auto flex items-end justify-between gap-3 pt-2">
                 <div>
-                  <div className="text-base font-semibold">{formatCOP(p.price)}</div>
+                  <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">
+                    {formatCOP(p.price)}
+                  </div>
                 </div>
                 <button
                   type="button"
@@ -67,7 +69,7 @@ function List({ items, onAdd, onQuickView }) {
                     }
                     onAdd(p);
                   }}
-                  className="h-10 w-10 grid place-items-center rounded-full bg-[#2f4131] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                  className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                 >
                   +
                 </button>


### PR DESCRIPTION
## Summary
- Remove side fades and redesign category tabs with higher chips and clearer labels
- Standardize product cards on light surfaces with consistent typography and aligned price/FAB

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae1a27de8483278f2e529f2bcb70cb