### PR TITLE
feat(ui): uniform chip sizes in CategoryBar/Tabs, switch to dark text; product cards to white theme

### DIFF
--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -117,7 +117,7 @@ export default function BowlsSection({ query, onCount, onQuickView }) {
 
       {/* Card del prearmado */}
       <article
-        className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition"
+        className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-2xl bg-white text-neutral-900 ring-1 ring-black/5 shadow-sm"
       >
         <button
           type="button"
@@ -139,8 +139,8 @@ export default function BowlsSection({ query, onCount, onQuickView }) {
           />
         </button>
         <div className="min-w-0 flex flex-col">
-          <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{preBowl.name}</h3>
-          <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{preBowl.desc}</p>
+          <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 truncate">{preBowl.name}</h3>
+          <p className="mt-0.5 text-sm text-neutral-600 line-clamp-2">{preBowl.desc}</p>
           <div className="mt-2 flex flex-wrap gap-2">
             {st === "low" && (
               <StatusChip variant="low">Pocas unidades</StatusChip>
@@ -151,7 +151,7 @@ export default function BowlsSection({ query, onCount, onQuickView }) {
           </div>
           <div className="mt-auto flex items-end justify-between gap-3 pt-2">
             <div>
-              <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">{formatCOP(preBowl.price)}</div>
+              <div className="text-base md:text-[17px] font-semibold text-neutral-900">{formatCOP(preBowl.price)}</div>
             </div>
             <button
               type="button"
@@ -164,7 +164,7 @@ export default function BowlsSection({ query, onCount, onQuickView }) {
                 }
                 handleAdd();
               }}
-              className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+              className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#263729] text-white shadow-sm ring-1 ring-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
             >
               +
             </button>

--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -1,7 +1,14 @@
 import { useEffect, useRef, useState } from "react";
-import clsx from "clsx";
 import { Icon } from "@iconify-icon/react";
 import { categoryIcons } from "../data/categoryIcons";
+
+const CHIP = {
+  base: "w-[116px] sm:w-[128px] h-[72px] rounded-xl bg-white ring-1 ring-neutral-200 grid grid-rows-[auto_1fr] place-items-center px-3 py-2 text-center select-none snap-center",
+  text: "text-[13px] leading-tight whitespace-normal break-words line-clamp-2",
+  icon: "w-6 h-6",
+  inactive: "text-neutral-700",
+  active: "bg-emerald-100 ring-emerald-300 text-emerald-800",
+};
 
 function IconWithFallback({ id, icon: iconProp, size = 24, className }) {
   const entry = iconProp ?? categoryIcons[id];
@@ -112,7 +119,7 @@ export default function CategoryBar({
     <div className="sticky top-0 z-40 bg-transparent backdrop-blur-[2px] border-b border-black/5 dark:border-white/10">
       <div
         role="tablist"
-        className="-mx-4 px-4 py-2 flex gap-3 md:gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory scrollbar-none relative"
+        className="-mx-4 px-4 py-2 flex gap-3 overflow-x-auto pb-1 no-scrollbar snap-x snap-mandatory scroll-smooth"
         onWheel={(e) => {
           if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
             e.currentTarget.scrollLeft += e.deltaY;
@@ -131,20 +138,15 @@ export default function CategoryBar({
               tabIndex={active ? 0 : -1}
               onKeyDown={handleKey}
               onClick={() => handleSelect(cat.id, idx)}
-              className={clsx(
-                "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-24 md:w-28 h-24 px-2",
-                "bg-white/30 backdrop-blur-md border border-black/10 dark:border-white/15",
-                "text-neutral-900 dark:text-neutral-50",
-                "shadow-[0_1px_0_rgba(0,0,0,0.02),0_8px_16px_-6px_rgba(0,0,0,0.12)]",
-                "hover:bg-white/40",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
-                active && "ring-2 ring-[#2f4131]/60 bg-white/50 border-black/10 dark:border-white/25"
-              )}
+              className={[CHIP.base, active ? CHIP.active : ""].join(" ")}
             >
-              <span className="w-12 h-12 rounded-full grid place-items-center shrink-0 bg-white/60 border border-white/70">
-                <IconWithFallback id={cat.id} className="w-7 h-7 object-contain" />
-              </span>
-              <span className="mt-1 text-sm font-semibold leading-tight text-neutral-900 dark:text-neutral-50 whitespace-normal break-words line-clamp-2">
+              <IconWithFallback
+                id={cat.id}
+                className={[CHIP.icon, active ? "text-emerald-800" : CHIP.inactive].join(" ")}
+              />
+              <span
+                className={[CHIP.text, active ? "text-emerald-800" : CHIP.inactive].join(" ")}
+              >
                 {cat.label}
               </span>
             </button>

--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -1,6 +1,13 @@
 import { useEffect, useRef, useState } from "react";
-import clsx from "clsx";
 import { Icon } from "@iconify-icon/react";
+
+const CHIP = {
+  base: "w-[116px] sm:w-[128px] h-[72px] rounded-xl bg-white ring-1 ring-neutral-200 grid grid-rows-[auto_1fr] place-items-center px-3 py-2 text-center select-none snap-center",
+  text: "text-[13px] leading-tight whitespace-normal break-words line-clamp-2",
+  icon: "w-6 h-6",
+  inactive: "text-neutral-700",
+  active: "bg-emerald-100 ring-emerald-300 text-emerald-800",
+};
 
 function IconWithFallback({ icon, size = 24, className }) {
   const initial = typeof icon === "string" ? icon : icon?.icon;
@@ -100,7 +107,7 @@ export default function CategoryTabs({
     <div className="sticky top-0 z-40 bg-transparent backdrop-blur-[2px] border-b border-black/5 dark:border-white/10">
       <div
         role="tablist"
-        className="-mx-4 px-4 py-2 flex gap-3 md:gap-4 overflow-x-auto scroll-smooth snap-x snap-mandatory scrollbar-none relative"
+        className="-mx-4 px-4 py-2 flex gap-3 overflow-x-auto pb-1 no-scrollbar snap-x snap-mandatory scroll-smooth"
         onWheel={(e) => {
           if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
             e.currentTarget.scrollLeft += e.deltaY;
@@ -119,20 +126,15 @@ export default function CategoryTabs({
               tabIndex={active ? 0 : -1}
               onKeyDown={handleKey}
               onClick={() => handleSelect(item.id, idx)}
-              className={clsx(
-                "inline-flex flex-col items-center justify-center text-center snap-start rounded-2xl w-24 md:w-28 h-24 px-2",
-                "bg-white/30 backdrop-blur-md border border-black/10 dark:border-white/15",
-                "text-neutral-900 dark:text-neutral-50",
-                "shadow-[0_1px_0_rgba(0,0,0,0.02),0_8px_16px_-6px_rgba(0,0,0,0.12)]",
-                "hover:bg-white/40",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]",
-                active && "ring-2 ring-[#2f4131]/60 bg-white/50 border-black/10 dark:border-white/25"
-              )}
+              className={[CHIP.base, active ? CHIP.active : ""].join(" ")}
             >
-              <span className="w-12 h-12 rounded-full grid place-items-center shrink-0 bg-white/60 border border-white/70">
-                <IconWithFallback icon={item.icon} className="w-7 h-7 object-contain" />
-              </span>
-              <span className="mt-1 text-sm font-semibold leading-tight text-neutral-900 dark:text-neutral-50 whitespace-normal break-words line-clamp-2">
+              <IconWithFallback
+                icon={item.icon}
+                className={[CHIP.icon, active ? "text-emerald-800" : CHIP.inactive].join(" ")}
+              />
+              <span
+                className={[CHIP.text, active ? "text-emerald-800" : CHIP.inactive].join(" ")}
+              >
                 {item.label}
               </span>
             </button>

--- a/src/components/CoffeeSection.jsx
+++ b/src/components/CoffeeSection.jsx
@@ -272,7 +272,7 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
               return (
                 <article
                   key={item.id}
-                  className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition"
+                  className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-2xl bg-white text-neutral-900 ring-1 ring-black/5 shadow-sm"
                 >
                   <button
                     type="button"
@@ -294,10 +294,10 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
                     />
                   </button>
                   <div className="min-w-0 flex flex-col">
-                    <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">
+                    <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 truncate">
                       {displayName(item)}
                     </h3>
-                    <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{item.desc}</p>
+                    <p className="mt-0.5 text-sm text-neutral-600 line-clamp-2">{item.desc}</p>
                     {hasControls && (
                       <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2">
                       {showAddMilk && (
@@ -331,7 +331,7 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
                   </div>
                     <div className="mt-auto flex items-end justify-between gap-3 pt-2">
                       <div>
-                        <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">
+                        <div className="text-base md:text-[17px] font-semibold text-neutral-900">
                           {formatCOP(finalPrice(item))}
                         </div>
                       </div>
@@ -346,7 +346,7 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
                           }
                           addToCart(item);
                         }}
-                        className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                        className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#263729] text-white shadow-sm ring-1 ring-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                       >
                         +
                       </button>
@@ -400,7 +400,7 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
             return (
               <article
                 key={item.id}
-                className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition"
+                className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-2xl bg-white text-neutral-900 ring-1 ring-black/5 shadow-sm"
               >
                 <button
                   type="button"
@@ -422,8 +422,8 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
                   />
                 </button>
                 <div className="min-w-0 flex flex-col">
-                  <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{displayName(item)}</h3>
-                  <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{item.desc}</p>
+                  <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 truncate">{displayName(item)}</h3>
+                  <p className="mt-0.5 text-sm text-neutral-600 line-clamp-2">{item.desc}</p>
                   <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2">
                     {isChai && <ChaiModeSelect id={item.id} />}
                     {showChaiMilk && (
@@ -443,7 +443,7 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
                   </div>
                   <div className="mt-auto flex items-end justify-between gap-3 pt-2">
                     <div>
-                      <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">{formatCOP(finalPrice(item))}</div>
+                      <div className="text-base md:text-[17px] font-semibold text-neutral-900">{formatCOP(finalPrice(item))}</div>
                     </div>
                     <button
                       type="button"
@@ -456,7 +456,7 @@ export default function CoffeeSection({ query, onCount, onQuickView }) {
                         }
                         addToCart(item);
                       }}
-                      className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                      className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#263729] text-white shadow-sm ring-1 ring-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                     >
                       +
                     </button>

--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -41,7 +41,7 @@ function Card({ item, onAdd, onQuickView }) {
     price: item.price,
   };
   return (
-    <article className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition">
+    <article className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-2xl bg-white text-neutral-900 ring-1 ring-black/5 shadow-sm">
       <button
         type="button"
         onClick={() => onQuickView?.(product)}
@@ -62,9 +62,9 @@ function Card({ item, onAdd, onQuickView }) {
         />
       </button>
       <div className="min-w-0 flex flex-col">
-        <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{item.name}</h3>
+        <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 truncate">{item.name}</h3>
         {item.desc && (
-          <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{item.desc}</p>
+          <p className="mt-0.5 text-sm text-neutral-600 line-clamp-2">{item.desc}</p>
         )}
         <div className="mt-2 flex flex-wrap gap-2">
           {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
@@ -72,13 +72,13 @@ function Card({ item, onAdd, onQuickView }) {
         </div>
         <div className="mt-auto flex items-end justify-between gap-3 pt-2">
           <div>
-            <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">{formatCOP(item.price)}</div>
+            <div className="text-base md:text-[17px] font-semibold text-neutral-900">{formatCOP(item.price)}</div>
           </div>
           <button
             type="button"
             aria-label={`Agregar ${item.name}`}
             onClick={handleAddClick}
-            className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+            className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#263729] text-white shadow-sm ring-1 ring-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
           >
             +
           </button>

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -456,7 +456,7 @@ function Desserts({ cumbre = [], base = [], onQuickView }) {
               return (
                 <article
                   key={s.id}
-                  className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition"
+                  className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-2xl bg-white text-neutral-900 ring-1 ring-black/5 shadow-sm"
                 >
                   <button
                     type="button"
@@ -478,7 +478,7 @@ function Desserts({ cumbre = [], base = [], onQuickView }) {
                     />
                   </button>
                   <div className="min-w-0 flex flex-col">
-                    <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{s.label}</h3>
+                    <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 truncate">{s.label}</h3>
                     <div className="mt-2 flex flex-wrap gap-2">
                       {st === "low" && (
                         <StatusChip variant="low">Pocas unidades</StatusChip>
@@ -489,7 +489,7 @@ function Desserts({ cumbre = [], base = [], onQuickView }) {
                     </div>
                     <div className="mt-auto flex items-end justify-between gap-3 pt-2">
                       <div>
-                        <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">{formatCOP(price)}</div>
+                        <div className="text-base md:text-[17px] font-semibold text-neutral-900">{formatCOP(price)}</div>
                       </div>
                       <button
                         type="button"
@@ -507,7 +507,7 @@ function Desserts({ cumbre = [], base = [], onQuickView }) {
                             options: { Sabor: s.label },
                           });
                         }}
-                        className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                        className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#263729] text-white shadow-sm ring-1 ring-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                       >
                         +
                       </button>
@@ -555,7 +555,7 @@ function ProductRow({ item, onQuickView }) {
     price: item.price,
   };
   return (
-    <article className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition">
+    <article className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-2xl bg-white text-neutral-900 ring-1 ring-black/5 shadow-sm">
       <button
         type="button"
         onClick={() => onQuickView?.(product)}
@@ -576,9 +576,9 @@ function ProductRow({ item, onQuickView }) {
         />
       </button>
       <div className="min-w-0 flex flex-col">
-        <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{item.name}</h3>
+        <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 truncate">{item.name}</h3>
         {item.desc && (
-          <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{item.desc}</p>
+          <p className="mt-0.5 text-sm text-neutral-600 line-clamp-2">{item.desc}</p>
         )}
         <div className="mt-2 flex flex-wrap gap-2">
           {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
@@ -586,7 +586,7 @@ function ProductRow({ item, onQuickView }) {
         </div>
         <div className="mt-auto flex items-end justify-between gap-3 pt-2">
           <div>
-            <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">
+            <div className="text-base md:text-[17px] font-semibold text-neutral-900">
               {typeof item.price === "number" ? formatCOP(item.price) : item.price}
             </div>
           </div>
@@ -601,7 +601,7 @@ function ProductRow({ item, onQuickView }) {
               }
               addItem({ productId: item.id, name: item.name, price: item.price });
             }}
-            className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+            className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#263729] text-white shadow-sm ring-1 ring-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
           >
             +
           </button>

--- a/src/components/Sandwiches.jsx
+++ b/src/components/Sandwiches.jsx
@@ -135,7 +135,7 @@ export default function Sandwiches({ query, onCount, onQuickView }) {
             return (
               <article
                 key={it.key}
-                className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition"
+                className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-2xl bg-white text-neutral-900 ring-1 ring-black/5 shadow-sm"
               >
                 <button
                   type="button"
@@ -157,10 +157,10 @@ export default function Sandwiches({ query, onCount, onQuickView }) {
                   />
                 </button>
                 <div className="min-w-0 flex flex-col">
-                  <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">
+                  <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 truncate">
                     {renderWithEmoji(it.name)}
                   </h3>
-                  <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">
+                  <p className="mt-0.5 text-sm text-neutral-600 line-clamp-2">
                     {renderWithEmoji(it.desc)}
                   </p>
                   <div className="mt-2 flex flex-wrap gap-2">
@@ -176,7 +176,7 @@ export default function Sandwiches({ query, onCount, onQuickView }) {
                   </div>
                   <div className="mt-auto flex items-end justify-between gap-3 pt-2">
                     <div>
-                      <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">
+                      <div className="text-base md:text-[17px] font-semibold text-neutral-900">
                         {formatCOP(price)}
                       </div>
                       {!priceByItem[it.key].unico && (
@@ -192,7 +192,7 @@ export default function Sandwiches({ query, onCount, onQuickView }) {
                         e.stopPropagation();
                         handleAdd();
                       }}
-                      className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                      className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#263729] text-white shadow-sm ring-1 ring-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                     >
                       +
                     </button>

--- a/src/components/SmoothiesSection.jsx
+++ b/src/components/SmoothiesSection.jsx
@@ -25,7 +25,7 @@ function List({ items, onAdd, onQuickView }) {
         return (
           <article
             key={p.name}
-            className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-3xl bg-white border border-black/5 dark:bg-neutral-900 dark:border-white/10 shadow-[0_1px_0_rgba(0,0,0,0.02),0_12px_24px_-10px_rgba(0,0,0,0.18)] hover:shadow-[0_1px_0_rgba(0,0,0,0.03),0_16px_30px_-10px_rgba(0,0,0,0.22)] transition"
+            className="group grid grid-cols-[96px_1fr] md:grid-cols-[112px_1fr] gap-3 md:gap-4 p-3 md:p-4 rounded-2xl bg-white text-neutral-900 ring-1 ring-black/5 shadow-sm"
           >
             <button
               type="button"
@@ -47,9 +47,9 @@ function List({ items, onAdd, onQuickView }) {
               />
             </button>
             <div className="min-w-0 flex flex-col">
-              <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100 truncate">{p.name}</h3>
+              <h3 className="text-base md:text-[17px] font-semibold text-neutral-900 truncate">{p.name}</h3>
               {p.desc && (
-                <p className="mt-0.5 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">{p.desc}</p>
+                <p className="mt-0.5 text-sm text-neutral-600 line-clamp-2">{p.desc}</p>
               )}
               <div className="mt-2 flex flex-wrap gap-2">
                 {st === "low" && <StatusChip variant="low">Pocas unidades</StatusChip>}
@@ -57,7 +57,7 @@ function List({ items, onAdd, onQuickView }) {
               </div>
               <div className="mt-auto flex items-end justify-between gap-3 pt-2">
                 <div>
-                  <div className="text-base md:text-[17px] font-semibold text-neutral-900 dark:text-neutral-100">
+                  <div className="text-base md:text-[17px] font-semibold text-neutral-900">
                     {formatCOP(p.price)}
                   </div>
                 </div>
@@ -72,7 +72,7 @@ function List({ items, onAdd, onQuickView }) {
                     }
                     onAdd(p);
                   }}
-                  className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#253525] text-white shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
+                  className="h-10 w-10 md:h-11 md:w-11 grid place-items-center rounded-full bg-[#2f4131] hover:bg-[#263729] text-white shadow-sm ring-1 ring-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#2f4131]"
                 >
                   +
                 </button>


### PR DESCRIPTION
## Summary
- standardize category chips with fixed dimensions and dark inactive text
- update product cards to white background, dark copy, and green add buttons

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae23825bf88327bd4ccb5f17e643c2