### PR TITLE
feat: add intent and size props to StatusChip

### DIFF
--- a/src/components/Buttons.jsx
+++ b/src/components/Buttons.jsx
@@ -112,18 +112,49 @@ export function AddIconButton({ className = "", disabled = false, variant = "sol
   );
 }
 
-// Chip de estado de inventario
-export function StatusChip({ variant = "neutral", className = "", children }) {
-  const map = {
-    low: "bg-amber-50 text-amber-800 border-amber-300",
-    soldout: "bg-neutral-100 text-neutral-700 border-neutral-200",
+/**
+ * Inventory status chip.
+ *
+ * @param {string} [intent]
+ *   Visual style: "warn", "error" or "neutral". Overrides `variant`.
+ * @param {string} [variant="neutral"]
+ *   Legacy prop kept for backward compatibility: "low", "soldout" or "neutral".
+ * @param {string} [size="xs"]
+ *   Chip size: "xs" (default) or "sm".
+ */
+export function StatusChip({
+  intent,
+  variant = "neutral",
+  size = "xs",
+  className = "",
+  children,
+}) {
+  const intentMap = {
+    warn: "bg-amber-50 text-amber-800 border-amber-300",
+    error: "bg-red-50 text-red-800 border-red-300",
     neutral: "bg-neutral-100 text-neutral-700 border-neutral-200",
   };
+
+  const variantMap = {
+    low: "warn",
+    soldout: "neutral",
+    neutral: "neutral",
+  };
+
+  const sizeMap = {
+    xs: "px-2 py-[3px] text-[11px]",
+    sm: "px-3 py-1 text-sm",
+  };
+
+  const color = intentMap[intent || variantMap[variant] || "neutral"];
+  const dimension = sizeMap[size] || sizeMap.xs;
+
   return (
     <span
       className={cx(
-        "inline-flex items-center rounded-full border px-2 py-[3px] text-[11px] leading-none font-medium",
-        map[variant],
+        "inline-flex items-center rounded-full border leading-none font-medium",
+        dimension,
+        color,
         className
       )}
     >

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -59,8 +59,8 @@ export default function ProductCard({ item, onAdd, onQuickView }) {
           <p className="mt-0.5 text-sm text-neutral-600 line-clamp-2">{item.desc}</p>
         )}
         <div className="mt-2 flex flex-wrap gap-2">
-          {st === 'low' && <StatusChip variant="low">Pocas unidades</StatusChip>}
-          {unavailable && <StatusChip variant="soldout">No Disponible</StatusChip>}
+          {st === 'low' && <StatusChip intent="warn">Pocas unidades</StatusChip>}
+          {unavailable && <StatusChip intent="neutral">No Disponible</StatusChip>}
         </div>
         <div className="mt-auto flex items-end justify-between gap-3 pt-2">
           <div>


### PR DESCRIPTION
## Summary
- allow StatusChip to accept `intent` and `size` props with backward-compatible `variant` mapping
- switch ProductCard to new StatusChip API

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae2c4748b0832797264c73ffde5ae0