### PR TITLE
refactor: unify category navigation and add section scroll offset

### DIFF
--- a/src/components/CategoryBar.jsx
+++ b/src/components/CategoryBar.jsx
@@ -1,3 +1,4 @@
+// TODO: remove this component in Fase 4 after QA
 import { useEffect, useRef, useState } from "react";
 import { Icon } from "@iconify-icon/react";
 import { categoryIcons } from "../data/categoryIcons";

--- a/src/components/CategoryNav.jsx
+++ b/src/components/CategoryNav.jsx
@@ -1,0 +1,119 @@
+import React from "react";
+import clsx from "clsx";
+import { Icon } from "@iconify-icon/react";
+import { categoryIcons } from "../data/categoryIcons";
+
+const CHIP = {
+  base: "w-[116px] sm:w-[128px] h-[72px] rounded-xl bg-white ring-1 ring-neutral-200 grid grid-rows-[auto_1fr] place-items-center px-3 py-2 text-center select-none snap-center",
+  text: "text-[13px] leading-tight whitespace-normal break-words line-clamp-2",
+  icon: "w-6 h-6",
+  inactive: "text-neutral-700",
+  active: "bg-emerald-100 ring-emerald-300 text-emerald-800",
+};
+
+const SCROLL_OFFSET = 96; // px; fallback si no hay CSS var
+
+function getIconDef(icon, id) {
+  if (icon) return icon;
+  const entry = categoryIcons[id];
+  return typeof entry === "string" ? entry : entry?.icon;
+}
+
+function scrollToSection(targetId) {
+  const el = document.getElementById(targetId);
+  if (!el) return;
+  const rect = el.getBoundingClientRect();
+  const y = window.scrollY + rect.top - SCROLL_OFFSET;
+  window.scrollTo({ top: Math.max(0, y), behavior: "smooth" });
+}
+
+export default function CategoryNav({
+  categories = [],      // [{ id, label, icon?, targetId?, tintClass? }]
+  activeId,             // opcional
+  onSelect,             // recibe (cat)
+  variant = (import.meta?.env?.VITE_FEATURE_TABS === "true" ? "tabs" : "bar"),
+}) {
+  const [selected, setSelected] = React.useState(activeId ?? categories[0]?.id);
+  const railRef = React.useRef(null);
+  const manualRef = React.useRef(0);
+
+  React.useEffect(() => { if (activeId) setSelected(activeId); }, [activeId]);
+
+  const handleSelect = (cat, idx) => {
+    setSelected(cat.id);
+    manualRef.current = Date.now();
+    onSelect?.(cat);
+    // Sólo en BAR hacemos scroll al section (tabs puede cambiar contenido arriba)
+    if (variant === "bar") {
+      const target = cat.targetId || `section-${cat.id}`;
+      scrollToSection(target);
+    }
+    // centrar chip en el carril
+    requestAnimationFrame(() => {
+      railRef.current?.children?.[idx]?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+    });
+  };
+
+  // Observa secciones para auto-selección (evitar bucle tras selección manual)
+  React.useEffect(() => {
+    if (variant !== "bar") return;
+    const secs = categories
+      .map((c) => document.getElementById(c.targetId || `section-${c.id}`))
+      .filter(Boolean);
+    if (!secs.length) return;
+    const io = new IntersectionObserver((entries) => {
+      if (Date.now() - manualRef.current < 700) return;
+      const visible = entries.filter(e => e.isIntersecting).sort((a,b)=>b.intersectionRatio - a.intersectionRatio)[0];
+      if (!visible?.target?.id) return;
+      const id = visible.target.id.replace(/^section-/, "");
+      if (id && id !== selected) {
+        setSelected(id);
+        const cat = categories.find((c) => c.id === id);
+        cat && onSelect?.(cat);
+      }
+    }, { threshold: [0.5] });
+    secs.forEach(s => io.observe(s));
+    return () => io.disconnect();
+  }, [categories, selected, variant, onSelect]);
+
+  const Wrapper = ({ children }) =>
+    variant === "tabs" ? (
+      <div className="mt-3 grid grid-cols-2 sm:grid-cols-3 gap-3">{children}</div>
+    ) : (
+      <div
+        ref={railRef}
+        className="flex gap-3 overflow-x-auto pb-2 no-scrollbar snap-x snap-mandatory"
+        onWheel={(e) => {
+          if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) e.currentTarget.scrollLeft += e.deltaY;
+        }}
+        role="tablist"
+        aria-label="Categorías"
+      >
+        {children}
+      </div>
+    );
+
+  return (
+    <Wrapper>
+      {categories.map((cat, idx) => {
+        const active = selected === cat.id;
+        const iconName = getIconDef(cat.icon, cat.id) || "ph:squares-four";
+        return (
+          <button
+            key={cat.id}
+            type="button"
+            onClick={() => handleSelect(cat, idx)}
+            className={clsx(CHIP.base, active && CHIP.active)}
+            role="tab"
+            aria-selected={active}
+            aria-controls={(cat.targetId || `section-${cat.id}`)}
+          >
+            <Icon className={clsx(CHIP.icon, active ? "text-emerald-800" : CHIP.inactive)} icon={iconName} />
+            <span className={clsx(CHIP.text, active ? "text-emerald-800" : CHIP.inactive)}>{cat.label}</span>
+          </button>
+        );
+      })}
+    </Wrapper>
+  );
+}
+

--- a/src/components/CategoryTabs.jsx
+++ b/src/components/CategoryTabs.jsx
@@ -1,3 +1,4 @@
+// TODO: remove this component in Fase 4 after QA
 import { useEffect, useRef, useState } from "react";
 import { Icon } from "@iconify-icon/react";
 

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -14,8 +14,7 @@ import ColdDrinksSection from "./ColdDrinksSection";
 import ProductQuickView from "./ProductQuickView";
 import { getProductImage } from "../utils/images";
 import CategoryHeader from "./CategoryHeader";
-import CategoryBar from "./CategoryBar";
-import CategoryTabs from "./CategoryTabs";
+import CategoryNav from "./CategoryNav";
 import { categoryIcons } from "../data/categoryIcons";
 import {
   breakfastItems,
@@ -375,29 +374,16 @@ export default function ProductLists({
   return (
     <>
       {!featureTabs && <CategoryHeader />}
-      {featureTabs ? (
-        <CategoryTabs
-          items={tabItems}
-          value={selectedCategory}
-          onChange={(slug) => {
-            if (slug === "todos") {
-              handleManualSelect({ id: "todos" });
-            } else {
-              const cat = categories.find((c) => c.id === slug);
-              handleManualSelect(cat ?? { id: "todos" });
-            }
-          }}
-          featureTabs={featureTabs}
-        />
-      ) : (
-        <CategoryBar
-          categories={[{ id: "todos", label: "Todos", tintClass: "bg-stone-100" }, ...categories]}
-          activeId={selectedCategory}
-          onSelect={(cat) => handleManualSelect(cat)}
-          variant="chip"
-          featureTabs={featureTabs}
-        />
-      )}
+      <CategoryNav
+        categories={
+          featureTabs
+            ? tabItems
+            : [{ id: "todos", label: "Todos", tintClass: "bg-stone-100" }, ...categories]
+        }
+        activeId={selectedCategory}
+        onSelect={(cat) => handleManualSelect(cat)}
+        variant={featureTabs ? "tabs" : "bar"}
+      />
       {query && !Object.values(counts).some((n) => n > 0) && (
         <p className="text-sm text-neutral-600 px-4">
           No hay resultados para “{query}”.

--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -15,7 +15,7 @@ export default function Section({ title, children, count, id: customId }) {
     <section
       id={id}
       data-aa-section={title}
-      className="scroll-mt-24 mb-6 last:mb-0"
+      className="scroll-mt-28 md:scroll-mt-32 mb-6 last:mb-0"
     >
       <h2 className="text-xl sm:text-2xl font-bold tracking-tight text-neutral-900">
         {title}


### PR DESCRIPTION
## Summary
- refactor: replace CategoryBar and CategoryTabs with unified CategoryNav component
- chore: mark old CategoryBar/CategoryTabs as deprecated for future removal
- feat: ensure sections align below sticky header using scroll margin

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae2f1c3ee483278374b8c93682de4f