### PR TITLE
refactor: restore carousel auto advance

### DIFF
--- a/src/components/PromoBannerCarousel.jsx
+++ b/src/components/PromoBannerCarousel.jsx
@@ -34,7 +34,31 @@ import { productStories } from "@/data/stories";
      if (paused || count <= 1) return;
      const el = trackRef.current;
      if (!el) return;
- export default function PromoBannerCarousel() {
+     const id = setInterval(() => {
+       const next = (index + 1) % count;
+       el.scrollTo({ left: next * el.clientWidth, behavior: "smooth" });
+     }, 6000);
+     return () => clearInterval(id);
+   }, [paused, count, index]);
+
+   const handleAction = (action, product, productId) => {
+     if (!action) return;
+     if (action === "add") {
+       if (product) {
+         addItem(product, 1);
+         toast();
+       } else {
+         toast("Producto no disponible");
+       }
+     } else if (action === "quickview") {
+       if (product) {
+         setQuickProduct(product);
+         setQuickOpen(true);
+       } else {
+         toast("Producto no disponible");
+       }
+     } else if (action === "modal:petfriendly") {
+       setPetOpen(true);
      } else if (action === "story" || action === "recipe") {
        const st = productStories[productId];
        if (!st) {


### PR DESCRIPTION
## Summary
- restore automatic slide advance in PromoBannerCarousel
- extract banner action handler into dedicated function and remove duplicate default export

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Expected ")" but found "}" in src/components/CartDrawer.jsx:105:10)*

------
https://chatgpt.com/codex/tasks/task_e_68ae734ed7848327a183e2ad27a0e653