### PR TITLE
Fix missing exports for cart context and stock utilities

### DIFF
--- a/src/context/CartContext.jsx
+++ b/src/context/CartContext.jsx
@@ -11,6 +11,8 @@ export const getItemUnit = (it) =>
   Number(String(it?.price ?? it?.unitPrice ?? it?.priceEach).replace(/[^\d.-]/g, "")) || 0;
 
 const CartCtx = createContext(null);
+
+export const useCart = () => useContext(CartCtx);
 const STORAGE_KEY = "aa_cart";
 
 function safeParse(json, fallback) {

--- a/src/utils/stock.js
+++ b/src/utils/stock.js
@@ -1,54 +1,24 @@
-// TODO(F6): eliminar si no se usa
-import { useRef, useEffect, useCallback, useMemo } from "react";
+import stock from "@/data/stock.json";
+import { toPlain } from "./strings";
 
-export default function useSwipeTabs({ onPrev, onNext, threshold = 40 } = {}) {
-  const startX = useRef(0);
-  const startY = useRef(0);
-  const triggered = useRef(false);
-  const onPrevRef = useRef(onPrev);
-  const onNextRef = useRef(onNext);
+export const slugify = (s = "") =>
+  toPlain(s)
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 
-  useEffect(() => {
-    onPrevRef.current = onPrev;
-  }, [onPrev]);
+const products = stock?.products || {};
 
-  useEffect(() => {
-    onNextRef.current = onNext;
-  }, [onNext]);
+export function getStockState(id) {
+  const state = products[id];
+  if (state === "low") return "low";
+  if (state === false) return "out";
+  return "in";
+}
 
-  const onTouchStart = useCallback((e) => {
-    if (triggered.current) return;
-    const t = e.touches && e.touches[0];
-    if (!t) return;
-    startX.current = t.clientX;
-    startY.current = t.clientY;
-  }, []);
-
-  const onTouchMove = useCallback(
-    (e) => {
-      if (triggered.current) return;
-      const t = e.touches && e.touches[0];
-      if (!t) return;
-      const dx = t.clientX - startX.current;
-      const dy = t.clientY - startY.current;
-      if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > threshold) {
-        triggered.current = true;
-        if (dx > 0) {
-          onPrevRef.current?.();
-        } else {
-          onNextRef.current?.();
-        }
-      }
-    },
-    [threshold],
-  );
-
-  const onTouchEnd = useCallback(() => {
-    triggered.current = false;
-  }, []);
-
-  return useMemo(
-    () => ({ onTouchStart, onTouchMove, onTouchEnd }),
-    [onTouchStart, onTouchMove, onTouchEnd],
-  );
+export function isUnavailable(itemOrId) {
+  const id =
+    typeof itemOrId === "string"
+      ? itemOrId
+      : itemOrId?.id || slugify(itemOrId?.name || "");
+  return getStockState(id) === "out";
 }


### PR DESCRIPTION
## Summary
- export `useCart` hook from CartContext
- implement stock utilities with `slugify`, `getStockState`, and `isUnavailable`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "../data/menuData")*

------
https://chatgpt.com/codex/tasks/task_e_68ae75cff5a88327b9929172448b22ce