### PR TITLE
Align HeroHeadline categories with config

### DIFF
--- a/src/components/HeroHeadline.jsx
+++ b/src/components/HeroHeadline.jsx
@@ -25,11 +25,12 @@ const templates = {
 const preferredTime = {
   desayunos: "mañana",
   bowls: "mañana",
-  "platos-fuertes": "tarde",
+  platos: "tarde",
   sandwiches: "noche",
+  smoothies: "tarde",
+  cafe: "mañana",
+  bebidasfrias: "tarde",
   postres: "tarde",
-  infusiones: "noche",
-  cafe: "mañana"
 };
 
 function getTimeContext() {


### PR DESCRIPTION
## Summary
- sync HeroHeadline's preferredTime keys with IDs from categories config

## Testing
- `npm run build` *(fails: Could not resolve "./Chip" from "src/components/SearchBar.jsx")*

------
https://chatgpt.com/codex/tasks/task_e_68ae779f81988327a911dcb389e0db18