### PR TITLE
Use categories list for hero

### DIFF
--- a/src/components/HeroHeadline.jsx
+++ b/src/components/HeroHeadline.jsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import { Link } from "react-scroll";
-import { menuCategories } from "../data/menuData"; // tu fuente real de categorías
+import { CATEGORIES_LIST as menuCategories } from "../config/categories";
 
 // Plantillas de frases para cada momento del día
 const templates = {
@@ -66,7 +66,7 @@ function getTimeContext() {
     templateList[Math.floor(Math.random() * templateList.length)];
 
   // Sustituimos {nombre} en la plantilla
-  const tip = randomTemplate.replace("{nombre}", randomCat.nombre);
+  const tip = randomTemplate.replace("{nombre}", randomCat.label);
 
   return {
     emoji: emojiMap[currentTime],


### PR DESCRIPTION
## Summary
- use `CATEGORIES_LIST` as source of hero menu categories
- access category names via `label`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Rollup failed to resolve import "@iconify/react")

------
https://chatgpt.com/codex/tasks/task_e_68ae790ec8848327ba95ada42b783d03