### PR TITLE
chore: update iconify import in search bar

### DIFF
--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@iconify-icon/react";
 import { Chip } from "./Buttons";
 
 const SUGGESTIONS = ["Veggie", "Sin gluten", "Café", "Bowl del día"];


### PR DESCRIPTION
## Summary
- use `@iconify-icon/react` in SearchBar
- ensure no remaining `@iconify/react` dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae7adf085c83279843e6ef339a4b26