### PR TITLE
fix(ProductLists): define swipeHandlers via react-swipeable and add safe fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-qr-code": "2.0.18",
-        "react-scroll": "^1.9.3"
+        "react-scroll": "^1.9.3",
+        "react-swipeable": "^7.0.2"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.2.0",
@@ -2505,6 +2506,15 @@
       "peerDependencies": {
         "react": "^15.5.4 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^15.5.4 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-qr-code": "2.0.18",
-    "react-scroll": "^1.9.3"
+    "react-scroll": "^1.9.3",
+    "react-swipeable": "^7.0.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",


### PR DESCRIPTION
## Summary
- install react-swipeable for gesture handling
- add swipeHandlers with safe fallbacks in ProductLists

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae7e40405c8327affe006fe1c4a7f7