### PR TITLE
chore: remove leading spaces in BowlBuilder imports

### DIFF
--- a/src/components/BowlBuilder.jsx
+++ b/src/components/BowlBuilder.jsx
@@ -1,8 +1,8 @@
 
- import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { formatCOP } from "@/utils/money";
 import { useCart } from "@/context/CartContext";
- import Portal from "./Portal";
+import Portal from "./Portal";
 import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
  
  // Tile ancho completo con estados


### PR DESCRIPTION
## Summary
- tidy BowlBuilder imports

## Testing
- `npm run build` *(fails: Rollup could not resolve module react-scroll)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7f774eb4832781188e115b7a45dd