### PR TITLE
fix(img): replace React-unknown fetchPriority with valid fetchpriority and add AAImage wrapper for priority/eager loading

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,6 +27,7 @@ module.exports = {
     "jsx-a11y/click-events-have-key-events": "off",
     "react-hooks/rules-of-hooks": "off",
     "jsx-a11y/label-has-associated-control": "off",
+    "react/no-unknown-property": ["error", { ignore: ["fetchpriority"] }],
   },
   ignorePatterns: ["dist", "build", "coverage", "node_modules"],
 };

--- a/src/components/BowlsSection.jsx
+++ b/src/components/BowlsSection.jsx
@@ -5,6 +5,7 @@ import { formatCOP } from "@/utils/money";
 import { matchesQuery } from "@/utils/strings";
 import { PILL_XS, PILL_SM } from "./Buttons";
 import { toast } from "./Toast";
+import AAImage from "@/components/ui/AAImage";
 const BowlBuilder = lazy(() => import("./BowlBuilder"));
 import { getStockState, slugify, isUnavailable } from "@/utils/stock";
 import { preBowl } from "@/data/menuItems";
@@ -58,13 +59,10 @@ export default function BowlsSection({ query, onCount, onQuickView }) {
       <div className="-mx-4 px-4 sm:-mx-6 sm:px-6">
         <div className="relative h-36 overflow-hidden rounded-2xl bg-gradient-to-r from-[#2f4131] to-[#355242] ring-1 ring-black/10 sm:h-44 md:h-56">
           {/* ← editar clases y ruta de la imagen aquí */}
-          <img
+          <AAImage
             src="/poke1.png"
             alt=""
             aria-hidden
-            loading="lazy"
-            decoding="async"
-            fetchPriority="low"
             className="pointer-events-none absolute bottom-[-6px] right-0 z-10 w-44 animate-[spin_40s_linear_infinite] object-contain drop-shadow-xl sm:right-2 sm:w-60 md:w-72"
           />
           <div className="absolute inset-0 grid grid-rows-[auto_1fr_auto] pb-16 pl-5 pr-40 pt-4 sm:pl-6 sm:pr-48 sm:pt-5">

--- a/src/components/BrandDecor.jsx
+++ b/src/components/BrandDecor.jsx
@@ -1,6 +1,8 @@
 // TODO(F6): eliminar si no se usa
 // src/components/BrandDecor.jsx
 // Muestra 4 imágenes fijas en las esquinas. Si falta una, se oculta sola.
+import AAImage from "@/components/ui/AAImage";
+
 export default function BrandDecor() {
   const hideIfMissing = (e) => {
     e.currentTarget.style.display = "none";
@@ -8,33 +10,37 @@ export default function BrandDecor() {
 
   return (
     <>
-      <img
+      <AAImage
         src="/decor-tl.png"
         alt=""
         aria-hidden="true"
         className="decor-img decor-tl"
         onError={hideIfMissing}
+        priority
       />
-      <img
+      <AAImage
         src="/decor-tr.png"
         alt=""
         aria-hidden="true"
         className="decor-img decor-tr"
         onError={hideIfMissing}
+        priority
       />
-      <img
+      <AAImage
         src="/decor-bl.png"
         alt=""
         aria-hidden="true"
         className="decor-img decor-bl"
         onError={hideIfMissing}
+        priority
       />
-      <img
+      <AAImage
         src="/decor-br.png"
         alt=""
         aria-hidden="true"
         className="decor-img decor-br"
         onError={hideIfMissing}
+        priority
       />
     </>
   );

--- a/src/components/CartDrawer.jsx
+++ b/src/components/CartDrawer.jsx
@@ -6,6 +6,7 @@ import { useCart, getItemUnit } from "@/context/CartContext";
 import { getProductImage } from "@/utils/images";
 import { MILK_OPTIONS } from "@/config/milkOptions";
 import { formatCOP } from "@/utils/money";
+import AAImage from "@/components/ui/AAImage";
  
  const safeNum = (raw) => {
    const n = String(raw || "").replace(/\D/g, "");
@@ -224,12 +225,10 @@ import { formatCOP } from "@/utils/money";
                   <SwipeRevealItem key={idx} onDelete={() => removeItem?.(it)}>
                     <div className="rounded-xl bg-white p-3 ring-1 ring-neutral-200">
                       <div className="flex items-start gap-3">
-                        <img
+                        <AAImage
                           src={getProductImage(it)}
                           alt=""
                           aria-hidden="true"
-                          loading="lazy"
-                          decoding="async"
                           className="h-12 w-12 rounded-md object-cover"
                         />
  

--- a/src/components/PetFriendlyModal.jsx
+++ b/src/components/PetFriendlyModal.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import Portal from "./Portal";
 import { cocoa } from "../data/petFriendly";
+import AAImage from "@/components/ui/AAImage";
 
 export default function PetFriendlyModal({ open, onClose }) {
   const [tab, setTab] = useState("cocoa");
@@ -93,10 +94,9 @@ export default function PetFriendlyModal({ open, onClose }) {
                     exit={{ opacity: 0, y: -10 }}
                     transition={{ duration: 0.25 }}
                   >
-                    <img
+                    <AAImage
                       src={cocoa.hero}
                       alt={cocoa.name}
-                      loading="lazy"
                       className="h-auto w-full rounded-lg"
                     />
                     <p className="mt-3 text-center text-sm">
@@ -135,11 +135,10 @@ export default function PetFriendlyModal({ open, onClose }) {
                     transition={{ duration: 0.25 }}
                   >
                     {cocoa.gallery.map((img, i) => (
-                      <img
+                      <AAImage
                         key={i}
                         src={img.src}
                         alt={img.alt}
-                        loading="lazy"
                         className="h-auto w-full rounded-lg object-cover"
                       />
                     ))}

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -3,6 +3,7 @@ import { getStockState, slugify, isUnavailable } from "@/utils/stock";
 import { getProductImage } from "@/utils/images";
 import { StatusChip } from "./Buttons";
 import { toast } from "./Toast";
+import AAImage from "@/components/ui/AAImage";
 
 export default function ProductCard({ item, onAdd, onQuickView }) {
   if (!item) return null;
@@ -51,10 +52,9 @@ export default function ProductCard({ item, onAdd, onQuickView }) {
         aria-label={`Ver ${product.title || product.name || "producto"}`}
         className="block overflow-hidden rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2"
       >
-        <img
+        <AAImage
           src={getProductImage(product)}
           alt={item.name || "Producto"}
-          loading="lazy"
           className="h-24 w-24 rounded-xl object-cover transition-transform duration-200 group-hover:scale-105 md:h-28 md:w-28"
         />
       </button>

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -17,6 +17,7 @@ import { matchesQuery } from "@/utils/strings";
 import { getProductImage } from "@/utils/images";
  import CategoryHeader from "./CategoryHeader";
  import CategoryNav from "./CategoryNav";
+import AAImage from "@/components/ui/AAImage";
  import {
    breakfastItems,
    mainDishes,
@@ -436,11 +437,10 @@ import { CATEGORIES_LIST, TABS_ITEMS } from "@/config/categories";
                      aria-label={`Ver ${product.title || product.name || "producto"}`}
                     className="block cursor-zoom-in rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2"
                    >
-                     <img
+                     <AAImage
                        src={getProductImage(product)}
                        alt={"Cumbre Andino"}
-                       loading="lazy"
-                      className="h-24 w-24 rounded-xl object-cover md:h-28 md:w-28"
+                       className="h-24 w-24 rounded-xl object-cover md:h-28 md:w-28"
                      />
                    </button>
                   <div className="flex min-w-0 flex-col">
@@ -533,11 +533,10 @@ import { CATEGORIES_LIST, TABS_ITEMS } from "@/config/categories";
          aria-label={`Ver ${product.title || product.name || "producto"}`}
         className="block cursor-zoom-in rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2"
        >
-         <img
+         <AAImage
            src={getProductImage(product)}
            alt={item.name || "Producto"}
-           loading="lazy"
-          className="h-24 w-24 rounded-xl object-cover md:h-28 md:w-28"
+           className="h-24 w-24 rounded-xl object-cover md:h-28 md:w-28"
          />
        </button>
       <div className="flex min-w-0 flex-col">

--- a/src/components/ProductQuickView.jsx
+++ b/src/components/ProductQuickView.jsx
@@ -6,6 +6,7 @@ import { formatCOP } from "@/utils/money";
 import { toast } from "./Toast";
 import { getProductImage } from "@/utils/images";
 import { MILK_OPTIONS, isMilkEligible } from "@/config/milkOptions";
+import AAImage from "@/components/ui/AAImage";
 
 export default function ProductQuickView({ open, product, onClose, onAdd }) {
   useLockBodyScroll(open);
@@ -112,11 +113,9 @@ export default function ProductQuickView({ open, product, onClose, onAdd }) {
             </button>
 
             {/* Elementos animados en secuencia */}
-            <img
+            <AAImage
               src={image}
               alt={title || product?.name || "Producto"}
-              loading="lazy"
-              decoding="async"
               className="mb-3 h-48 w-full rounded-xl object-cover"
               style={stagger(0)}
             />

--- a/src/components/PromoBannerCarousel.jsx
+++ b/src/components/PromoBannerCarousel.jsx
@@ -9,6 +9,7 @@ import { useCart } from "@/context/CartContext";
  import { toast } from "./Toast";
 import { formatCOP } from "@/utils/money";
 import { productStories } from "@/data/stories";
+import AAImage from "@/components/ui/AAImage";
  
  export default function PromoBannerCarousel() {
    const { addItem } = useCart();
@@ -101,7 +102,7 @@ import { productStories } from "@/data/stories";
              setIndex(newIndex);
            }}
          >
-           {items.map((item) => {
+           {items.map((item, i) => {
              const { product } = item;
              const price = Number(product?.price);
              const canAdd = !!product && Number.isFinite(price) && price > 0;
@@ -109,14 +110,13 @@ import { productStories } from "@/data/stories";
              const viewLabel = item.ctas?.secondary?.label || "Ver";
              return (
               <div key={item.id} className="relative h-44 w-full flex-shrink-0 snap-center sm:h-56">
-                 <img
-                   src={item.image}
-                   alt={item.alt || item.title}
-                   loading="lazy"
-                   referrerPolicy="no-referrer"
-                   decoding="async"
+                <AAImage
+                  src={item.image}
+                  alt={item.alt || item.title}
+                  referrerPolicy="no-referrer"
                   className="absolute inset-0 z-0 h-full w-full object-cover"
-                 />
+                  priority={i === 0}
+                />
                 <div className="pointer-events-none absolute inset-0 z-10 bg-gradient-to-t from-black/55 via-black/25 to-transparent" />
                 <div className="pointer-events-auto relative z-30 flex h-full w-full flex-col justify-end p-4">
                   <h3 className="text-lg font-semibold text-white">{item.title}</h3>

--- a/src/components/QrPoster.jsx
+++ b/src/components/QrPoster.jsx
@@ -1,5 +1,6 @@
 // src/components/QrPoster.jsx
 import QRCode from "react-qr-code";
+import AAImage from "@/components/ui/AAImage";
 
 export default function QrPoster({ url }) {
   // Lee ?t= de la URL para “Mesa”
@@ -38,10 +39,11 @@ export default function QrPoster({ url }) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-alto-beige p-6 text-alto-text print:bg-white">
       <div className="w-full max-w-md rounded-3xl border bg-white p-6 text-center shadow-xl print:border-0 print:shadow-none">
-        <img
+        <AAImage
           src="/logoalto.png"
           alt="Alto Andino"
           className="mx-auto mb-3 h-20 w-20 object-contain"
+          priority
         />
         <h1 className="text-lg font-extrabold">
           Menú QR {table ? `· Mesa ${table}` : ""}

--- a/src/components/StoryModal.jsx
+++ b/src/components/StoryModal.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import Portal from "./Portal";
+import AAImage from "@/components/ui/AAImage";
 
 export default function StoryModal({ open, onClose, story }) {
   const [visible, setVisible] = useState(false);
@@ -57,10 +58,9 @@ export default function StoryModal({ open, onClose, story }) {
           {story.sections?.map((sec, i) => (
             <div key={i} className="mb-4 last:mb-0">
               {sec.image && (
-                <img
+                <AAImage
                   src={sec.image}
                   alt={sec.heading}
-                  loading="lazy"
                   className="mb-2 h-auto w-full rounded-md"
                 />
               )}

--- a/src/components/ui/AAImage.jsx
+++ b/src/components/ui/AAImage.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+export default function AAImage({
+  src,
+  alt = "",
+  className = "",
+  priority = false,
+  width,
+  height,
+  ...rest
+}) {
+  const common = {
+    alt,
+    className,
+    width,
+    height,
+    decoding: "async",
+    ...rest,
+  };
+
+  if (priority) {
+    return (
+      <img
+        src={src}
+        {...common}
+        fetchpriority="high"
+        loading="eager"
+      />
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      {...common}
+      loading="lazy"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- introduce AAImage component to standardize lazy/eager image loading
- swap direct `<img>` tags for AAImage and correct `fetchpriority` usage across components
- silence ESLint for the `fetchpriority` attribute

## Testing
- `npx --yes eslint@8 .` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae815fa8f083279ad771a940b54126