### PR TITLE
Fix cold drinks tab rendering and targeting

### DIFF
--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -1,20 +1,78 @@
+// src/components/ColdDrinksSection.jsx
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import ProductSection from "./ProductSection";
-import { sodas, otherDrinks } from "@/data/menuItems";
+import * as menu from "@/data/menuItems";
+
+// Devuelve el primer array no vacío de los candidatos (string = clave de menu).
+function pickArray(...candidates) {
+  for (const c of candidates) {
+    const arr = typeof c === "string" ? menu[c] : c;
+    if (Array.isArray(arr) && arr.length > 0) return arr;
+  }
+  return [];
+}
 
 export default function ColdDrinksSection({ query, onCount, onQuickView }) {
-  const groups = [
-    { title: "Gaseosas y Sodas", items: sodas },
-    { title: "Jugos y otras bebidas frías", items: otherDrinks },
+  const [visible, setVisible] = useState(false);
+  const ref = useRef(null);
+
+  // Ajusta o añade claves según tu data real en src/data/menuItems.js
+  const groupsRaw = [
+    { title: "Gaseosas y Sodas",            items: pickArray("sodas", "gaseosas") },
+    { title: "Jugos y otras bebidas frías", items: pickArray("otherDrinks", "jugos", "bebidasFrias", "bebidasfrias") },
+    { title: "Limonadas",                    items: pickArray("lemonades", "limonadas") },
+    { title: "Aguas",                        items: pickArray("waters", "aguas") },
+    { title: "Frappés",                      items: pickArray("frappes", "frappesCold") },
   ];
 
+  // Filtra grupos vacíos
+  const groups = useMemo(
+    () => groupsRaw.filter(g => Array.isArray(g.items) && g.items.length > 0),
+    [groupsRaw]
+  );
+
+  // Si hay un solo grupo, ProductSection acepta [{ items }] sin título.
+  const finalGroups = useMemo(() => {
+    if (groups.length > 1) return groups;
+    if (groups.length === 1) return [{ items: groups[0].items }];
+    return []; // sin datos no rompe
+  }, [groups]);
+
+  // Reporta total de ítems al padre (para contadores o tabs)
+  useEffect(() => {
+    const total = groups.reduce((acc, g) => acc + g.items.length, 0);
+    onCount?.(total);
+  }, [groups, onCount]);
+
+  // Fade-in al aparecer en viewport
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setVisible(true);
+        io.unobserve(el);
+      }
+    }, { threshold: 0.15 });
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
   return (
-    <ProductSection
-      id="bebidasfrias"
-      title="Bebidas frías"
-      query={query}
-      groups={groups}
-      onCount={onCount}
-      onQuickView={onQuickView}
-    />
+    <div
+      ref={ref}
+      className={`transition-all duration-500 ease-out ${
+        visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
+      }`}
+    >
+      <ProductSection
+        id="bebidasfrias"            // 👈 importante: usamos este id
+        title="Bebidas frías"
+        query={query}
+        groups={finalGroups}
+        onCount={onCount}
+        onQuickView={onQuickView}
+      />
+    </div>
   );
 }

--- a/src/config/categories.js
+++ b/src/config/categories.js
@@ -25,7 +25,7 @@ export const CATEGORIES_LIST = [
   {
     id: "bebidasfrias",
     label: "Bebidas frías",
-    targetId: "section-bebidas-frias",
+    targetId: "section-bebidasfrias",
     tintClass: "bg-sky-50",
   },
   { id: "postres", label: "Postres" },


### PR DESCRIPTION
## Summary
- Improve cold drinks section to auto-pick available drink arrays and fade in when visible
- Align cold drinks category target id for proper tab navigation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae962ae8288327a7511a0fc8f30601