### PR TITLE
feat: add product image mapping and null-safe rendering

### DIFF
--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -4,7 +4,6 @@ import { getProductImage } from "@/utils/images";
 import { StatusChip } from "./Buttons";
 import { toast } from "./Toast";
 import AAImage from "@/components/ui/AAImage";
-import { getProductImage } from "@/utils/images";
 
 // Comentario guía encima de donde uses <img> o <AAImage>:
 {/* Las imágenes de producto se configuran en src/utils/images.js.
@@ -27,6 +26,8 @@ export default function ProductCard({ item, onAdd, onQuickView }) {
     price: item.price,
   };
 
+  const imageSrc = getProductImage(product);
+
   const handleQuickView = () => onQuickView?.(product);
 
   const handleKeyDown = (e) => {
@@ -47,26 +48,30 @@ export default function ProductCard({ item, onAdd, onQuickView }) {
 
   return (
     <article
-      className={`group grid grid-cols-[96px_1fr] gap-3 rounded-2xl bg-white p-3 text-neutral-900 shadow-sm ring-1 ring-black/5 transition-all duration-200 md:grid-cols-[112px_1fr] md:gap-4 md:p-4 hover:shadow-md hover:ring-black/10 hover:-translate-y-0.5 ${
+      className={`group grid ${
+        imageSrc ? "grid-cols-[96px_1fr] md:grid-cols-[112px_1fr]" : "grid-cols-1"
+      } gap-3 rounded-2xl bg-white p-3 text-neutral-900 shadow-sm ring-1 ring-black/5 transition-all duration-200 md:gap-4 md:p-4 hover:shadow-md hover:ring-black/10 hover:-translate-y-0.5 ${
         unavailable ? "opacity-70 grayscale" : ""
       }`}
     >
-      <button
-        type="button"
-        onClick={handleQuickView}
-        onKeyDown={handleKeyDown}
-        aria-label={`Ver ${product.title || product.name || "producto"}`}
-        className="block overflow-hidden rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2"
-      >
-        // Las imágenes de producto se configuran en src/utils/images.js.
-        // Pon tus archivos en /public/img/products y mapea la clave en IMAGE_MAP
+      {imageSrc && (
+        <button
+          type="button"
+          onClick={handleQuickView}
+          onKeyDown={handleKeyDown}
+          aria-label={`Ver ${product.title || product.name || "producto"}`}
+          className="block overflow-hidden rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2"
+        >
+          // Las imágenes de producto se configuran en src/utils/images.js.
+          // Pon tus archivos en /public/img/products y mapea la clave en IMAGE_MAP
 
-        <AAImage
-          src={getProductImage(product)}
-          alt={item.name || "Producto"}
-          className="h-24 w-24 rounded-xl object-cover transition-transform duration-200 group-hover:scale-105 md:h-28 md:w-28"
-        />
-      </button>
+          <AAImage
+            src={imageSrc}
+            alt={item.name || "Producto"}
+            className="h-24 w-24 rounded-xl object-cover transition-transform duration-200 group-hover:scale-105 md:h-28 md:w-28"
+          />
+        </button>
+      )}
 
       <div className="flex min-w-0 flex-col">
         <h3 className="truncate text-base font-semibold text-neutral-900 md:text-[17px]">

--- a/src/components/ProductQuickView.jsx
+++ b/src/components/ProductQuickView.jsx
@@ -8,7 +8,6 @@ import { toast } from "./Toast";
 import { getProductImage } from "@/utils/images";
 import { MILK_OPTIONS, isMilkEligible } from "@/config/milkOptions";
 import AAImage from "@/components/ui/AAImage";
-import { getProductImage } from "@/utils/images";
 
 // Comentario guía encima de donde uses <img> o <AAImage>:
 {/* Las imágenes de producto se configuran en src/utils/images.js.

--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -4,8 +4,8 @@
 // 1) Pon tus imágenes en: /public/img/products/
 //    Ej.: /public/img/products/coffee-capuccino.jpg
 // 2) Mapea aquí debajo en IMAGE_MAP usando un id o un slug manual.
-// 3) Si no hay match, se intentará /img/products/<slug>.jpg; si tampoco existe,
-//    usa PLACEHOLDER (crea /public/img/products/placeholder.jpg).
+// 3) Si no hay match, se intentará /img/products/<slug> con las extensiones
+//    .png y .jpg. Si tampoco existe, retornará null.
 
 function slugify(s = "") {
   return String(s)
@@ -22,6 +22,7 @@ export const IMAGE_MAP = {
 
   // === SANDWICHES ===
   "sandwich:pollo": "/img/products/sandwich-pollo.jpg",
+  "sandwich:cerdo": "/img/products/sancerdo1.png",
 
   // === BOWLS ===
   "bowl:prearmado": "/img/products/bowl-prearmado.jpg",
@@ -30,18 +31,26 @@ export const IMAGE_MAP = {
   // "<productId-o-slug>": "/img/products/mi-foto.jpg",
 };
 
-export const PLACEHOLDER = "/img/products/placeholder.jpg";
-
 /**
  * Dado un producto { id?, name? }, devuelve una ruta de imagen.
  * 1) Busca en IMAGE_MAP por id o slug(name)
- * 2) Si no, intenta /img/products/<slug>.jpg
- * 3) Si no, PLACEHOLDER
+ * 2) Si no, intenta /img/products/<slug>.png o .jpg
+ * 3) Si no, retorna null
  */
 export function getProductImage(product) {
-  if (!product) return PLACEHOLDER;
+  if (!product) return null;
   const key = product.id || (product.name ? slugify(product.name) : "");
   if (key && IMAGE_MAP[key]) return IMAGE_MAP[key];
-  if (key) return `/img/products/${key}.jpg`;
-  return PLACEHOLDER;
+
+  for (const ext of ["png", "jpg"]) {
+    const url = `/img/products/${key}.${ext}`;
+    const req = new XMLHttpRequest();
+    try {
+      req.open("HEAD", url, false);
+      req.send();
+      if (req.status >= 200 && req.status < 400) return url;
+    } catch {}
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- map existing products to base image paths
- support png and jpg extensions in `getProductImage`
- render product card images only when available
- remove duplicate image import in quick view to fix build

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af66a414fc8327ab56b441598d0181