### PR TITLE
Ensure cold drinks section renders immediately

### DIFF
--- a/src/components/ColdDrinksSection.jsx
+++ b/src/components/ColdDrinksSection.jsx
@@ -1,5 +1,5 @@
 // src/components/ColdDrinksSection.jsx
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import ProductSection from "./ProductSection";
 import * as menu from "@/data/menuItems";
 
@@ -13,8 +13,6 @@ function pickArray(...candidates) {
 }
 
 export default function ColdDrinksSection({ query, onCount, onQuickView }) {
-  const [visible, setVisible] = useState(false);
-  const ref = useRef(null);
 
   const groupsRaw = [
     { title: "Gaseosas y Sodas",            items: pickArray("sodas", "gaseosas") },
@@ -45,25 +43,8 @@ export default function ColdDrinksSection({ query, onCount, onQuickView }) {
     }
   }, [groups, onCount]);
 
-  // Animación al entrar a viewport
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const io = new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting) {
-        setVisible(true);
-        io.unobserve(el);
-      }
-    }, { threshold: 0.15 });
-    io.observe(el);
-    return () => io.disconnect();
-  }, []);
-
   return (
-    <div
-      ref={ref}
-      className={`transition-all duration-500 ease-out ${visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}`}
-    >
+    <div className="transition-all duration-500 ease-out opacity-100 translate-y-0">
       <ProductSection
         id="bebidasfrias"
         title="Bebidas frías"

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -4,7 +4,6 @@ import { getProductImage } from "@/utils/images";
 import { StatusChip } from "./Buttons";
 import { toast } from "./Toast";
 import AAImage from "@/components/ui/AAImage";
-import { getProductImage } from "@/utils/images";
 
 // Comentario guía encima de donde uses <img> o <AAImage>:
 {/* Las imágenes de producto se configuran en src/utils/images.js.

--- a/src/components/ProductQuickView.jsx
+++ b/src/components/ProductQuickView.jsx
@@ -8,7 +8,6 @@ import { toast } from "./Toast";
 import { getProductImage } from "@/utils/images";
 import { MILK_OPTIONS, isMilkEligible } from "@/config/milkOptions";
 import AAImage from "@/components/ui/AAImage";
-import { getProductImage } from "@/utils/images";
 
 // Comentario guía encima de donde uses <img> o <AAImage>:
 {/* Las imágenes de producto se configuran en src/utils/images.js.


### PR DESCRIPTION
## Summary
- Show cold drinks section without waiting for viewport intersection
- Remove duplicate image imports in product card and quick view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af66a7c5f883279de7028f7870f037