### PR TITLE
Hide AAImage when src missing to keep ProductCard layout consistent

### DIFF
--- a/src/components/ui/AAImage.jsx
+++ b/src/components/ui/AAImage.jsx
@@ -9,6 +9,8 @@ export default function AAImage({
   height,
   ...rest
 }) {
+  if (!src) return null;
+
   const common = {
     alt,
     className,


### PR DESCRIPTION
## Summary
- Avoid rendering AAImage when src is absent to prevent empty image slots
- ProductCard already omits the image container when no src, keeping text full width

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af681bb40883279203e4935ef3f5d1