### PR TITLE
feat: virtualize product lists with react-window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react-dom": "^18.2.0",
         "react-qr-code": "2.0.18",
         "react-scroll": "^1.9.3",
-        "react-swipeable": "^7.0.2"
+        "react-swipeable": "^7.0.2",
+        "react-window": "^1.8.11"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.2.0",
@@ -23,6 +24,9 @@
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.10",
         "vite": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -284,6 +288,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2015,6 +2028,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2515,6 +2534,23 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^18.2.0",
     "react-qr-code": "2.0.18",
     "react-scroll": "^1.9.3",
-    "react-swipeable": "^7.0.2"
+    "react-swipeable": "^7.0.2",
+    "react-window": "^1.8.11"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useEffect, useCallback, useState, useRef } from "react";
+import { FixedSizeList } from "react-window";
 import { useSwipeable } from "react-swipeable";
 import { useCart } from "../context/CartContext";
 import { formatCOP } from "../utils/money";
@@ -459,17 +460,29 @@ import { CATEGORIES_LIST, TABS_ITEMS } from "../config/categories";
    );
  }
  
- function List({ items, onQuickView }) {
-   return (
-     <ul className="space-y-3">
-       {items.map((p) => (
-         <ProductRow key={p.id} item={p} onQuickView={onQuickView} />
-       ))}
-     </ul>
-   );
- }
- 
- function ProductRow({ item, onQuickView }) {
+function List({ items, onQuickView }) {
+  const ITEM_SIZE = 120;
+  const height = Math.min(items.length * ITEM_SIZE, 600);
+  return (
+    <FixedSizeList
+      height={height}
+      itemCount={items.length}
+      itemSize={ITEM_SIZE}
+      width="100%"
+    >
+      {({ index, style }) => (
+        <ProductRow
+          index={index}
+          style={style}
+          item={items[index]}
+          onQuickView={onQuickView}
+        />
+      )}
+    </FixedSizeList>
+  );
+}
+
+function ProductRow({ item, onQuickView, style, index }) {
   const { addItem } = useCart();
   const st = getStockState(item.id || slugify(item.name));
   const unavailable = st === "out" || isUnavailable(item);
@@ -484,7 +497,8 @@ import { CATEGORIES_LIST, TABS_ITEMS } from "../config/categories";
   const [imgReady, setImgReady] = useState(false);
   const imgSrc = getProductImage(product);
   return (
-    <article className={`group grid ${imgSrc && imgReady ? "grid-cols-[96px_1fr] md:grid-cols-[112px_1fr]" : "grid-cols-1"} gap-3 rounded-2xl bg-white p-3 text-neutral-900 shadow-sm ring-1 ring-black/5 md:gap-4 md:p-4 ${unavailable ? "opacity-70 grayscale" : ""}`}>
+    <div style={style} className="pb-3">
+      <article className={`group grid ${imgSrc && imgReady ? "grid-cols-[96px_1fr] md:grid-cols-[112px_1fr]" : "grid-cols-1"} gap-3 rounded-2xl bg-white p-3 text-neutral-900 shadow-sm ring-1 ring-black/5 md:gap-4 md:p-4 ${unavailable ? "opacity-70 grayscale" : ""}`}>
       {/* Pre-carga oculta para no reservar espacio */}
       {imgSrc && !imgReady && (
         <AAImage
@@ -550,6 +564,7 @@ import { CATEGORIES_LIST, TABS_ITEMS } from "../config/categories";
            </button>
          </div>
        </div>
-     </article>
-   );
- }
+      </article>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- virtualize product list rendering using `react-window`
- pass virtualized style and index to `ProductRow`
- keep quick view and stock checks intact

## Testing
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68afb68e8e7c83278cb73e56dc769a7d