### PR TITLE
refactor: sustituye framer-motion en modales

### DIFF
--- a/src/components/GuideModal.jsx
+++ b/src/components/GuideModal.jsx
@@ -1,8 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { motion, AnimatePresence } from "framer-motion";
 
 export default function GuideModal({ open, onClose, children }) {
+  const [visible, setVisible] = useState(false);
+
   useEffect(() => {
     const onKey = (e) => {
       if (e.key === "Escape") onClose?.();
@@ -11,44 +12,42 @@ export default function GuideModal({ open, onClose, children }) {
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
+  useEffect(() => {
+    if (open) {
+      setVisible(true);
+    } else {
+      const t = setTimeout(() => setVisible(false), 200);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  if (!visible) return null;
+
   return createPortal(
-    <AnimatePresence>
-      {open && (
-        <motion.div
-          className="fixed inset-0 z-[80] flex items-center justify-center"
-          aria-modal="true"
-          role="dialog"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
+    <div
+      className={`fixed inset-0 z-[80] flex items-center justify-center transition-opacity duration-200 ${
+        open ? "opacity-100" : "opacity-0"
+      }`}
+      aria-modal="true"
+      role="dialog"
+    >
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div
+        className={`relative w-[92%] max-w-md rounded-2xl bg-[#FAF7F2] p-5 shadow-lg transition-all duration-200 ease-out ${
+          open ? "scale-100 opacity-100" : "scale-95 opacity-0"
+        }`}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Cerrar"
+          className="absolute right-3 top-3 grid h-8 w-8 place-items-center rounded-full bg-black/5 hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2"
         >
-          <motion.div
-            className="absolute inset-0 bg-black/40"
-            onClick={onClose}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-          />
-          <motion.div
-            className="relative w-[92%] max-w-md rounded-2xl bg-[#FAF7F2] p-5 shadow-lg"
-            initial={{ scale: 0.95, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            exit={{ scale: 0.95, opacity: 0 }}
-            transition={{ duration: 0.25, ease: "easeOut" }}
-          >
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label="Cerrar"
-              className="absolute right-3 top-3 grid h-8 w-8 place-items-center rounded-full bg-black/5 hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2"
-            >
-              ×
-            </button>
-            {children}
-          </motion.div>
-        </motion.div>
-      )}
-    </AnimatePresence>,
+          ×
+        </button>
+        {children}
+      </div>
+    </div>,
     document.body
   );
 }

--- a/src/components/PetFriendlyModal.jsx
+++ b/src/components/PetFriendlyModal.jsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
 import Portal from "./Portal";
 import { cocoa } from "../data/petFriendly";
 import AAImage from "@/components/ui/AAImage";
 
 export default function PetFriendlyModal({ open, onClose }) {
   const [tab, setTab] = useState("cocoa");
+  const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     const onKey = (e) => {
@@ -15,6 +15,17 @@ export default function PetFriendlyModal({ open, onClose }) {
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
+  useEffect(() => {
+    if (open) {
+      setVisible(true);
+    } else {
+      const t = setTimeout(() => setVisible(false), 200);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  if (!visible) return null;
+
   const tabs = [
     { id: "cocoa", label: "Cocoa" },
     { id: "philosophy", label: "Filosofía" },
@@ -23,132 +34,104 @@ export default function PetFriendlyModal({ open, onClose }) {
 
   return (
     <Portal>
-      <AnimatePresence>
-        {open && (
-          <motion.div
-            className="fixed inset-0 z-[80] flex items-center justify-center"
-            role="dialog"
-            aria-modal="true"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
+      <div
+        className={`fixed inset-0 z-[80] flex items-center justify-center transition-opacity duration-200 ${
+          open ? "opacity-100" : "opacity-0"
+        }`}
+        role="dialog"
+        aria-modal="true"
+      >
+        {/* Fondo */}
+        <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+
+        {/* Contenedor */}
+        <div
+          className={`relative max-h-[90vh] w-[92%] max-w-lg overflow-y-auto rounded-2xl bg-white p-5 transition-all duration-200 ease-out dark:bg-neutral-900 dark:text-neutral-100 ${
+            open ? "scale-100 opacity-100 translate-y-0" : "scale-95 opacity-0 translate-y-5"
+          }`}
+        >
+          {/* Botón cerrar */}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Cerrar"
+            className="absolute right-3 top-3 grid h-8 w-8 place-items-center rounded-full bg-black/5 hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2"
           >
-            {/* Fondo */}
-            <motion.div
-              className="absolute inset-0 bg-black/50"
-              onClick={onClose}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 0.5 }}
-              exit={{ opacity: 0 }}
-            />
+            ×
+          </button>
 
-            {/* Contenedor */}
-            <motion.div
-              className="relative max-h-[90vh] w-[92%] max-w-lg overflow-y-auto rounded-2xl bg-white p-5 dark:bg-neutral-900 dark:text-neutral-100"
-              initial={{ scale: 0.95, opacity: 0, y: 20 }}
-              animate={{ scale: 1, opacity: 1, y: 0 }}
-              exit={{ scale: 0.95, opacity: 0, y: 20 }}
-              transition={{ type: "spring", stiffness: 300, damping: 25 }}
-            >
-              {/* Botón cerrar */}
+          {/* Tabs */}
+          <div className="mb-4" role="tablist">
+            {tabs.map((t) => (
               <button
-                type="button"
-                onClick={onClose}
-                aria-label="Cerrar"
-                className="absolute right-3 top-3 grid h-8 w-8 place-items-center rounded-full bg-black/5 hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2"
+                key={t.id}
+                id={`tab-${t.id}`}
+                role="tab"
+                aria-selected={tab === t.id}
+                aria-controls={`panel-${t.id}`}
+                onClick={() => setTab(t.id)}
+                className={`mb-2 mr-2 rounded-full px-3 py-1 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2 ${
+                  tab === t.id
+                    ? "bg-[#2f4131] text-white"
+                    : "bg-black/5 text-neutral-700 hover:bg-black/10"
+                }`}
               >
-                ×
+                {t.label}
               </button>
+            ))}
+          </div>
 
-              {/* Tabs */}
-              <div className="mb-4" role="tablist">
-                {tabs.map((t) => (
-                  <button
-                    key={t.id}
-                    id={`tab-${t.id}`}
-                    role="tab"
-                    aria-selected={tab === t.id}
-                    aria-controls={`panel-${t.id}`}
-                    onClick={() => setTab(t.id)}
-                    className={`mb-2 mr-2 rounded-full px-3 py-1 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2 ${
-                      tab === t.id
-                        ? "bg-[#2f4131] text-white"
-                        : "bg-black/5 text-neutral-700 hover:bg-black/10"
-                    }`}
-                  >
-                    {t.label}
-                  </button>
-                ))}
-              </div>
+          {/* Contenido dinámico */}
+          {tab === "cocoa" && (
+            <div
+              id="panel-cocoa"
+              role="tabpanel"
+              aria-labelledby="tab-cocoa"
+              className="transition-opacity duration-200"
+            >
+              <AAImage
+                src={cocoa.hero}
+                alt={cocoa.name}
+                className="h-auto w-full rounded-lg"
+              />
+              <p className="mt-3 text-center text-sm">
+                Conoce a {cocoa.name}, nuestra pitbull bonsái.
+              </p>
+            </div>
+          )}
 
-              {/* Contenido dinámico con animación */}
-              <AnimatePresence mode="wait">
-                {tab === "cocoa" && (
-                  <motion.div
-                    key="cocoa"
-                    id="panel-cocoa"
-                    role="tabpanel"
-                    aria-labelledby="tab-cocoa"
-                    initial={{ opacity: 0, y: 10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -10 }}
-                    transition={{ duration: 0.25 }}
-                  >
-                    <AAImage
-                      src={cocoa.hero}
-                      alt={cocoa.name}
-                      className="h-auto w-full rounded-lg"
-                    />
-                    <p className="mt-3 text-center text-sm">
-                      Conoce a {cocoa.name}, nuestra pitbull bonsái.
-                    </p>
-                  </motion.div>
-                )}
+          {tab === "philosophy" && (
+            <div
+              id="panel-philosophy"
+              role="tabpanel"
+              aria-labelledby="tab-philosophy"
+              className="transition-opacity duration-200"
+            >
+              <p className="whitespace-pre-line text-sm">
+                {cocoa.philosophy}
+              </p>
+            </div>
+          )}
 
-                {tab === "philosophy" && (
-                  <motion.div
-                    key="philosophy"
-                    id="panel-philosophy"
-                    role="tabpanel"
-                    aria-labelledby="tab-philosophy"
-                    initial={{ opacity: 0, y: 10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -10 }}
-                    transition={{ duration: 0.25 }}
-                  >
-                    <p className="whitespace-pre-line text-sm">
-                      {cocoa.philosophy}
-                    </p>
-                  </motion.div>
-                )}
-
-                {tab === "gallery" && (
-                  <motion.div
-                    key="gallery"
-                    id="panel-gallery"
-                    role="tabpanel"
-                    aria-labelledby="tab-gallery"
-                    className="grid grid-cols-2 gap-2 sm:grid-cols-3"
-                    initial={{ opacity: 0, y: 10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: -10 }}
-                    transition={{ duration: 0.25 }}
-                  >
-                    {cocoa.gallery.map((img, i) => (
-                      <AAImage
-                        key={i}
-                        src={img.src}
-                        alt={img.alt}
-                        className="h-auto w-full rounded-lg object-cover"
-                      />
-                    ))}
-                  </motion.div>
-                )}
-              </AnimatePresence>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+          {tab === "gallery" && (
+            <div
+              id="panel-gallery"
+              role="tabpanel"
+              aria-labelledby="tab-gallery"
+              className="grid grid-cols-2 gap-2 transition-opacity duration-200 sm:grid-cols-3"
+            >
+              {cocoa.gallery.map((img, i) => (
+                <AAImage
+                  key={i}
+                  src={img.src}
+                  alt={img.alt}
+                  className="h-auto w-full rounded-lg object-cover"
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
     </Portal>
   );
 }


### PR DESCRIPTION
## Summary
- replace framer-motion in GuideModal and PetFriendlyModal with CSS transitions
- small bundle size improvement (~3 kB) after removing motion from modals

## Testing
- `npm run build -- --report` *(fails: Unknown option `--report`)*
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68afb6a3c43c832790976158b7006669