### PR TITLE
fix: remove stray closing div in ProductLists

### DIFF
--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -565,6 +565,5 @@ function ProductRow({ item, onQuickView, style, index }) {
          </div>
        </div>
       </article>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
- fix extraneous closing `div` at end of ProductLists component

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "react-window")*
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68afb893b25483279e43ffeacbcf29e5