### PR TITLE
fix: define catálogos faltantes

### DIFF
--- a/src/data/menuItems.js
+++ b/src/data/menuItems.js
@@ -381,3 +381,11 @@ export const otherDrinks = [
     desc: "Kiwi, Granada, Maracuyá, Manzana verde, Mangostino",
   },
 ];
+
+// Categorías pendientes de catalogar
+export const lemonades = [];
+export const waters = [];
+export const frappes = [];
+
+// Alias para mantener compatibilidad con componentes existentes
+export const functionalSmoothies = funcionales;


### PR DESCRIPTION
## Resumen
- añade catálogos vacíos para limonadas, aguas y frappés
- expone alias `functionalSmoothies` para los smoothies funcionales

## Testing
- `npm run build`
- `npm run preview` *(falló el despliegue a Vercel por token inválido)*

------
https://chatgpt.com/codex/tasks/task_e_68afd71512dc8327879d810f9129c083