### PR TITLE
fix: ajustar layout de hero y productos

### DIFF
--- a/src/components/HeroHeadline.jsx
+++ b/src/components/HeroHeadline.jsx
@@ -143,7 +143,12 @@ export default function HeroHeadline() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.6, duration: 0.4 }}
       >
-        <span className="absolute right-3 top-3 text-2xl sm:text-3xl" aria-hidden>{emoji}</span>
+        <span
+          className="pointer-events-none absolute right-3 top-3 -z-10 text-2xl sm:text-3xl md:-right-10 md:top-1/2 md:-translate-y-1/2 md:text-5xl"
+          aria-hidden
+        >
+          {emoji}
+        </span>
         <div className="flex-1">
           <p className="text-sm font-medium text-[#2f4131]">{label}</p>
           <p className="text-xs text-neutral-700">{tip}</p>

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -111,7 +111,7 @@ export default function ProductCard({ item, onAdd, onQuickView }) {
             type="button"
             aria-label={`Agregar ${item.name || "producto"}`}
             onClick={handleAdd}
-            className="grid h-10 w-10 place-items-center rounded-full bg-[#2f4131] text-white shadow-sm ring-1 ring-black/5 transition-transform duration-150 hover:scale-110 hover:bg-[#263729] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2 md:h-11 md:w-11"
+            className="grid h-10 w-10 place-items-center rounded-full bg-[#2f4131] text-white shadow-sm ring-1 ring-black/5 transition-transform duration-150 hover:scale-110 hover:bg-[#263729] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2f4131] focus-visible:ring-offset-2 md:h-11 md:w-11 flex-shrink-0"
           >
             +
           </button>

--- a/src/components/ProductSection.jsx
+++ b/src/components/ProductSection.jsx
@@ -87,7 +87,7 @@ export default function ProductSection({
   }
 
   const renderProducts = (arr, keySeed = 0) => (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 sm:gap-4">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
       {arr.map((item, i) => {
         const safeItem = typeof mapItem === "function" ? mapItem(item) : item;
         return (


### PR DESCRIPTION
## Resumen
- evita solapamiento del emoji con el CTA en el encabezado
- limita grilla de productos a dos columnas en escritorio
- preserva tamaño del botón flotante de agregar

## Testing
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68b1c2a3c32c83278ac616d60ece7960