### PR TITLE
feat: checkout flow with order creation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,19 +7,28 @@ import Splash from "./views/Splash";
 import Hub from "./views/Hub";
 import MenuView from "./views/MenuView";
 import TiendaView from "./views/TiendaView";
+import Checkout from "./views/Checkout";
 import MiniCart from "./components/shared/MiniCart";
 
 function AppScreens() {
   const { setArea, applyRealtimePatch } = useAppState();
-  const [screen, setScreen] = useState("splash");
+  const [screen, setScreen] = useState(() =>
+    window.location.pathname === "/checkout" ? "checkout" : "splash",
+  );
 
   const handleSplashFinish = (next) => {
     // next can be "hub", "menu" or "tienda"
+    if (window.location.pathname !== "/") {
+      window.history.replaceState(null, "", "/");
+    }
     setScreen(next);
   };
 
   const handleAreaSelect = (area) => {
     setArea(area);
+    if (window.location.pathname !== "/") {
+      window.history.replaceState(null, "", "/");
+    }
     setScreen(area);
   };
 
@@ -33,11 +42,12 @@ function AppScreens() {
   else if (screen === "hub") content = <Hub onSelect={handleAreaSelect} />;
   else if (screen === "menu") content = <MenuView onSwitch={() => handleAreaSelect("tienda")} />;
   else if (screen === "tienda") content = <TiendaView onSwitch={() => handleAreaSelect("menu")} />;
+  else if (screen === "checkout") content = <Checkout />;
 
   return (
     <div className="flex min-h-screen flex-col">
       {content}
-      <MiniCart />
+      {screen !== "checkout" && <MiniCart />}
     </div>
   );
 }

--- a/src/components/shared/MiniCart.jsx
+++ b/src/components/shared/MiniCart.jsx
@@ -6,6 +6,12 @@ export default function MiniCart() {
   const count = cart?.items?.length || 0;
   const incompatible = getIncompatibleItemsForMode(mode);
 
+  const disabled = count === 0 || incompatible.length > 0;
+
+  const goCheckout = () => {
+    if (!disabled) window.location.href = "/checkout";
+  };
+
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-white shadow md:top-0 md:bottom-auto md:left-auto md:right-0 md:m-4 md:w-64 md:rounded md:border">
       <div className="flex flex-col gap-2 border-t p-4 md:border-0">
@@ -30,10 +36,16 @@ export default function MiniCart() {
             <span className="text-sm">{count}</span>
           </div>
           <button
-            disabled
-            className="cursor-not-allowed rounded bg-gray-300 px-4 py-2 text-gray-500"
+            onClick={goCheckout}
+            disabled={disabled}
+            className={[
+              "rounded px-4 py-2 text-sm",
+              disabled
+                ? "cursor-not-allowed bg-gray-300 text-gray-500"
+                : "bg-[#2f4131] text-white hover:bg-[#243326]",
+            ].join(" ")}
           >
-            Revisar pedido
+            Ir al checkout
           </button>
         </div>
       </div>

--- a/src/services/orders.js
+++ b/src/services/orders.js
@@ -1,0 +1,75 @@
+// src/services/orders.js
+import supabase from "@/lib/supabaseClient";
+
+/**
+ * Crea una orden y sus items asociados.
+ * @param {Object} payload
+ * @param {string} payload.mode - mesa | pickup | delivery
+ * @param {string|null} payload.tableId
+ * @param {Object} payload.contact - {name, phone}
+ * @param {Object} payload.address - {line, notes}
+ * @param {string} payload.notes - notas generales
+ * @param {string} payload.payment_method - cash | online
+ * @param {Array} payload.items - items del carrito
+ * @param {Object} payload.totals - {subtotal_cop, delivery_fee_cop, total_cop}
+ * @returns {Promise<string>} id de la orden creada
+ */
+export async function createOrder({
+  mode,
+  tableId,
+  contact = {},
+  address = {},
+  notes,
+  payment_method,
+  items = [],
+  totals = {},
+}) {
+  if (!supabase) throw new Error("Supabase no configurado");
+
+  const status = payment_method === "cash" ? "awaiting_cash" : "pending";
+
+  const { data: orderData, error: orderError } = await supabase
+    .from("orders")
+    .insert({
+      mode,
+      table_id: tableId || null,
+      contact_name: contact.name || null,
+      contact_phone: contact.phone || null,
+      address_line: address.line || null,
+      address_notes: address.notes || null,
+      notes: notes || null,
+      payment_method,
+      status,
+      subtotal_cop: totals.subtotal_cop || 0,
+      delivery_fee_cop: totals.delivery_fee_cop || 0,
+      total_cop: totals.total_cop || 0,
+    })
+    .select("id")
+    .single();
+
+  if (orderError || !orderData) {
+    throw orderError || new Error("No se pudo crear la orden");
+  }
+
+  const orderId = orderData.id;
+
+  const itemsPayload = items.map((it) => ({
+    order_id: orderId,
+    product_id: it.productId,
+    name: it.name,
+    unit_price_cop: it.unit_price_cop,
+    qty: it.qty,
+    subtotal_cop: (it.unit_price_cop || 0) * (it.qty || 1),
+  }));
+
+  const { error: itemsError } = await supabase
+    .from("order_items")
+    .insert(itemsPayload);
+
+  if (itemsError) {
+    await supabase.from("orders").delete().eq("id", orderId);
+    throw itemsError;
+  }
+
+  return orderId;
+}

--- a/src/state/appState.js
+++ b/src/state/appState.js
@@ -72,7 +72,13 @@ export function AppStateProvider({ children }) {
     }));
   };
 
-  const resetCart = () => setCart({ items: [] });
+  const clearCart = () => setCart({ items: [] });
+
+  const getCartTotalCop = () =>
+    cart.items.reduce(
+      (sum, it) => sum + (it.unit_price_cop || 0) * (it.qty || 1),
+      0,
+    );
 
   const applyRealtimePatch = (p) =>
     setProducts((prev) =>
@@ -91,7 +97,8 @@ export function AppStateProvider({ children }) {
     setArea,
     getIncompatibleItemsForMode,
     removeItemsByIds,
-    resetCart,
+    clearCart,
+    getCartTotalCop,
     setCategories,
     setProducts,
     applyRealtimePatch,
@@ -100,4 +107,9 @@ export function AppStateProvider({ children }) {
 }
 
 export const useAppState = () => useContext(AppStateContext);
+
+export const useCartItems = () => {
+  const { cart } = useAppState();
+  return cart.items;
+};
 

--- a/src/views/Checkout.jsx
+++ b/src/views/Checkout.jsx
@@ -1,0 +1,216 @@
+// src/views/Checkout.jsx
+import { useState } from "react";
+import { useAppState } from "@/state/appState";
+import { createOrder } from "@/services/orders";
+import { formatCOP } from "@/utils/money";
+import { toast } from "@/components/Toast";
+
+export default function Checkout() {
+  const {
+    mode,
+    tableId,
+    cart,
+    getIncompatibleItemsForMode,
+    clearCart,
+    getCartTotalCop,
+  } = useAppState();
+  const [form, setForm] = useState({
+    contact_name: "",
+    contact_phone: "",
+    address_line: "",
+    address_notes: "",
+    notes: "",
+    payment_method: "cash",
+  });
+  const [orderId, setOrderId] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const items = cart.items || [];
+  const incompatible = getIncompatibleItemsForMode(mode);
+  const subtotal = getCartTotalCop();
+  const total = subtotal;
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const isValid = () => {
+    if (mode === "mesa") return true;
+    if (!form.contact_name) return false;
+    if (!/^\d{10}$/.test(form.contact_phone)) return false;
+    if (mode === "delivery" && !form.address_line) return false;
+    return true;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (incompatible.length > 0) return;
+    if (!isValid()) {
+      toast("Faltan campos obligatorios");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const id = await createOrder({
+        mode,
+        tableId,
+        contact: {
+          name: form.contact_name,
+          phone: form.contact_phone,
+        },
+        address: {
+          line: form.address_line,
+          notes: form.address_notes,
+        },
+        notes: form.notes,
+        payment_method: mode === "mesa" ? "cash" : form.payment_method,
+        items,
+        totals: {
+          subtotal_cop: subtotal,
+          delivery_fee_cop: 0,
+          total_cop: total,
+        },
+      });
+      clearCart();
+      try {
+        window.localStorage.setItem("lastOrderId", id);
+      } catch {}
+      setOrderId(id);
+    } catch (err) {
+      console.error(err);
+      toast("No se pudo crear la orden");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (orderId) {
+    return (
+      <div className="p-4 space-y-2">
+        <h2 className="text-xl font-semibold">Orden creada</h2>
+        <p className="text-sm">Modo: {mode}</p>
+        <p className="text-sm">Número de orden: {orderId}</p>
+        <p className="text-sm">Total: {formatCOP(total)}</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-4">
+      {mode !== "mesa" && (
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm text-neutral-700">Nombre</label>
+            <input
+              name="contact_name"
+              value={form.contact_name}
+              onChange={handleChange}
+              className="mt-1 w-full rounded border p-2 text-sm"
+              required={mode !== "mesa"}
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-neutral-700">Teléfono</label>
+            <input
+              name="contact_phone"
+              value={form.contact_phone}
+              onChange={handleChange}
+              className="mt-1 w-full rounded border p-2 text-sm"
+              inputMode="numeric"
+              pattern="\d{10}"
+              required={mode !== "mesa"}
+            />
+          </div>
+        </div>
+      )}
+
+      {mode === "mesa" && (
+        <div>
+          <label className="block text-sm text-neutral-700">Nombre (opcional)</label>
+          <input
+            name="contact_name"
+            value={form.contact_name}
+            onChange={handleChange}
+            className="mt-1 w-full rounded border p-2 text-sm"
+          />
+        </div>
+      )}
+
+      {mode === "delivery" && (
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm text-neutral-700">Dirección</label>
+            <input
+              name="address_line"
+              value={form.address_line}
+              onChange={handleChange}
+              className="mt-1 w-full rounded border p-2 text-sm"
+              required={mode === "delivery"}
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-neutral-700">Notas de dirección (opcional)</label>
+            <input
+              name="address_notes"
+              value={form.address_notes}
+              onChange={handleChange}
+              className="mt-1 w-full rounded border p-2 text-sm"
+            />
+          </div>
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm text-neutral-700">Notas (opcional)</label>
+        <textarea
+          name="notes"
+          value={form.notes}
+          onChange={handleChange}
+          className="mt-1 w-full rounded border p-2 text-sm"
+          rows={2}
+        />
+      </div>
+
+      {mode !== "mesa" && (
+        <div className="space-y-2">
+          <p className="text-sm text-neutral-700">Método de pago</p>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="payment_method"
+              value="cash"
+              checked={form.payment_method === "cash"}
+              onChange={handleChange}
+            />
+            Pagar en caja
+          </label>
+          <label className="flex items-center gap-2 text-sm text-neutral-400">
+            <input type="radio" disabled />
+            Pagar en línea (Bold)
+          </label>
+        </div>
+      )}
+
+      <div className="space-y-1">
+        <h3 className="font-medium">Resumen</h3>
+        <ul className="space-y-1">
+          {items.map((it) => (
+            <li key={it.id} className="text-sm">
+              {it.qty}× {it.name} - {formatCOP((it.unit_price_cop || 0) * (it.qty || 1))}
+            </li>
+          ))}
+        </ul>
+        <p className="text-sm font-semibold">Total: {formatCOP(total)}</p>
+      </div>
+
+      <button
+        type="submit"
+        disabled={submitting || incompatible.length > 0 || !isValid()}
+        className="w-full rounded bg-[#2f4131] py-2 text-white disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-500"
+      >
+        Confirmar pedido
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add checkout view with mode-based form and order creation
- create orders service to persist orders and items
- expose cart helpers and checkout access from mini cart

## Testing
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68c08722f9fc8327aea9eaae43534cde