### PR TITLE
fix: enable cart additions

### DIFF
--- a/src/components/shared/MiniCart.jsx
+++ b/src/components/shared/MiniCart.jsx
@@ -1,10 +1,17 @@
 // src/components/shared/MiniCart.jsx
 import { useAppState } from "../../state/appState";
+import { formatCOP } from "@/utils/money";
 
 export default function MiniCart() {
-  const { cart, mode, getIncompatibleItemsForMode } = useAppState();
+  const {
+    cart,
+    mode,
+    getIncompatibleItemsForMode,
+    getCartTotalCop,
+  } = useAppState();
   const count = cart?.items?.length || 0;
   const incompatible = getIncompatibleItemsForMode(mode);
+  const total = getCartTotalCop();
 
   const disabled = count === 0 || incompatible.length > 0;
 
@@ -33,7 +40,9 @@ export default function MiniCart() {
             >
               <path d="M3 3h2l.4 2M7 13h10l4-8H5.4" stroke="currentColor" strokeWidth="2" fill="none" />
             </svg>
-            <span className="text-sm">{count}</span>
+            <span className="text-sm">
+              {count} · {formatCOP(total)}
+            </span>
           </div>
           <button
             onClick={goCheckout}

--- a/src/views/MenuView.jsx
+++ b/src/views/MenuView.jsx
@@ -21,6 +21,7 @@ export default function MenuView({ onSwitch }) {
     setProducts,
     mode,
     tableId,
+    addToCart,
   } = useAppState();
 
   const [visible, setVisible] = useState(false);
@@ -77,9 +78,10 @@ export default function MenuView({ onSwitch }) {
         (p.tags || []).some((tag) => tag.toLowerCase().includes(t))
       );
     })
-    .filter((p) =>
-      onlyCompatible ? (p.fulfillment_modes || []).includes(mode) : true
-    );
+    .filter((p) => {
+      const modes = p.fulfillment_modes || ["mesa", "pickup", "delivery"];
+      return onlyCompatible ? modes.includes(mode) : true;
+    });
 
   useEffect(() => {
     const handleScroll = () => {
@@ -185,7 +187,8 @@ export default function MenuView({ onSwitch }) {
         {visibleProducts.map((p) => {
           const unavailable = !p.is_available || p.stock <= 0;
           const img = p.image_url || `/img/products/${p.slug || p.id}.jpg`;
-          const compatible = (p.fulfillment_modes || []).includes(mode);
+          const modes = p.fulfillment_modes || ["mesa", "pickup", "delivery"];
+          const compatible = modes.includes(mode);
           const badge = MODE_BADGES[mode];
           return (
             <div
@@ -217,6 +220,7 @@ export default function MenuView({ onSwitch }) {
               <button
                 disabled={unavailable || !compatible}
                 title={!compatible ? badge : undefined}
+                onClick={() => addToCart(p)}
                 className={`self-center rounded-full px-3 py-1 text-sm ${
                   unavailable || !compatible
                     ? "bg-gray-300 text-gray-500 cursor-not-allowed"

--- a/src/views/TiendaView.jsx
+++ b/src/views/TiendaView.jsx
@@ -21,6 +21,7 @@ export default function TiendaView({ onSwitch }) {
     setProducts,
     mode,
     tableId,
+    addToCart,
   } = useAppState();
 
   const [visible, setVisible] = useState(false);
@@ -77,9 +78,10 @@ export default function TiendaView({ onSwitch }) {
         (p.tags || []).some((tag) => tag.toLowerCase().includes(t))
       );
     })
-    .filter((p) =>
-      onlyCompatible ? (p.fulfillment_modes || []).includes(mode) : true
-    );
+    .filter((p) => {
+      const modes = p.fulfillment_modes || ["mesa", "pickup", "delivery"];
+      return onlyCompatible ? modes.includes(mode) : true;
+    });
 
   useEffect(() => {
     const handleScroll = () => {
@@ -185,7 +187,8 @@ export default function TiendaView({ onSwitch }) {
         {visibleProducts.map((p) => {
           const unavailable = !p.is_available || p.stock <= 0;
           const img = p.image_url || `/img/products/${p.slug || p.id}.jpg`;
-          const compatible = (p.fulfillment_modes || []).includes(mode);
+          const modes = p.fulfillment_modes || ["mesa", "pickup", "delivery"];
+          const compatible = modes.includes(mode);
           const badge = MODE_BADGES[mode];
           return (
             <div
@@ -220,6 +223,7 @@ export default function TiendaView({ onSwitch }) {
               <button
                 disabled={unavailable || !compatible}
                 title={!compatible ? badge : undefined}
+                onClick={() => addToCart(p)}
                 className={`mt-2 w-full rounded-full px-3 py-1 text-sm ${
                   unavailable || !compatible
                     ? "bg-gray-300 text-gray-500 cursor-not-allowed"


### PR DESCRIPTION
## Summary
- persist cart in global state and add `addToCart` handler
- enforce fulfillment mode compatibility with sensible defaults
- show cart total in MiniCart

## Testing
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68c09750e62c83278c21e0aa502719b2