### PR TITLE
fix: add SPA fallback and client-side checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-qr-code": "2.0.18",
+        "react-router-dom": "^6.30.1",
         "react-scroll": "^1.9.3",
         "react-swipeable": "^7.0.2",
         "react-window": "^1.8.11"
@@ -864,6 +865,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2610,6 +2620,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scroll": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-qr-code": "2.0.18",
+    "react-router-dom": "^6.30.1",
     "react-scroll": "^1.9.3",
     "react-swipeable": "^7.0.2",
     "react-window": "^1.8.11"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 // src/App.jsx
 import { useState, useEffect } from "react";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AppStateProvider, useAppState } from "./state/appState";
 import { subscribeAvailability } from "./services/catalog";
 
@@ -12,9 +13,7 @@ import MiniCart from "./components/shared/MiniCart";
 
 function AppScreens() {
   const { setArea, applyRealtimePatch } = useAppState();
-  const [screen, setScreen] = useState(() =>
-    window.location.pathname === "/checkout" ? "checkout" : "splash",
-  );
+  const [screen, setScreen] = useState("splash");
 
   const handleSplashFinish = (next) => {
     // next can be "hub", "menu" or "tienda"
@@ -42,12 +41,11 @@ function AppScreens() {
   else if (screen === "hub") content = <Hub onSelect={handleAreaSelect} />;
   else if (screen === "menu") content = <MenuView onSwitch={() => handleAreaSelect("tienda")} />;
   else if (screen === "tienda") content = <TiendaView onSwitch={() => handleAreaSelect("menu")} />;
-  else if (screen === "checkout") content = <Checkout />;
 
   return (
     <div className="flex min-h-screen flex-col">
       {content}
-      {screen !== "checkout" && <MiniCart />}
+      <MiniCart />
     </div>
   );
 }
@@ -55,7 +53,12 @@ function AppScreens() {
 export default function App() {
   return (
     <AppStateProvider>
-      <AppScreens />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/checkout" element={<Checkout />} />
+          <Route path="*" element={<AppScreens />} />
+        </Routes>
+      </BrowserRouter>
     </AppStateProvider>
   );
 }

--- a/src/components/shared/MiniCart.jsx
+++ b/src/components/shared/MiniCart.jsx
@@ -1,5 +1,6 @@
 // src/components/shared/MiniCart.jsx
 import { useAppState } from "../../state/appState";
+import { useNavigate } from "react-router-dom";
 import { formatCOP } from "@/utils/money";
 
 export default function MiniCart() {
@@ -15,8 +16,10 @@ export default function MiniCart() {
 
   const disabled = count === 0 || incompatible.length > 0;
 
+  const navigate = useNavigate();
+
   const goCheckout = () => {
-    if (!disabled) window.location.href = "/checkout";
+    if (!disabled) navigate("/checkout");
   };
 
   return (

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "framework": "vite"
+  "framework": "vite",
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/$1" },
+    { "source": "/(.*)\\.(.*)", "destination": "/$1.$2" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
 }


### PR DESCRIPTION
## Summary
- add Vercel rewrites for SPA fallback while preserving /api and assets
- route checkout through React Router and navigate via MiniCart

## Testing
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68c09973f3e083279f38ad24c7e4b9f4