### PR TITLE
feat: add total_cop to order_items and compute item subtotals

### DIFF
--- a/src/services/orders.js
+++ b/src/services/orders.js
@@ -61,13 +61,16 @@ export async function createOrder({
 
   const orderId = orderData.id;
 
-  const itemsPayload = items.map((it) => ({
-    order_id: orderId,
-    product_id: it.productId,
-    qty: it.qty,
-    unit_price_cop: it.unit_price_cop,
-    total_cop: (it.unit_price_cop || 0) * (it.qty || 1),
-  }));
+  const itemsPayload = items.map((it) => {
+    const unitPrice = it.unit_price_cop ?? it.price_cop ?? 0;
+    return {
+      order_id: orderId,
+      product_id: it.productId ?? it.id,
+      qty: it.qty,
+      unit_price_cop: unitPrice,
+      total_cop: unitPrice * (it.qty || 0),
+    };
+  });
 
   const { error: itemsError } = await supabase
     .from("order_items")

--- a/supabase/migrations/20240520120000_add_total_cop_to_order_items.sql
+++ b/supabase/migrations/20240520120000_add_total_cop_to_order_items.sql
@@ -1,0 +1,2 @@
+alter table order_items
+add column total_cop numeric not null default 0;


### PR DESCRIPTION
## Summary
- add migration for `order_items.total_cop`
- calculate and persist `total_cop` when creating orders

## Testing
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68c0a9cd80688327a59519739a5b4121